### PR TITLE
chore: enrol Tier 1 agentic SDLC automation

### DIFF
--- a/.github/tier1/AGENTIC.md
+++ b/.github/tier1/AGENTIC.md
@@ -1,0 +1,73 @@
+# Tier 1 agent backends
+
+Three ways to run triage / docs-drift / CI diagnose:
+
+| Mode | Config | Where the “agent” is | Secrets |
+| --- | --- | --- | --- |
+| `heuristic` | default | None — keyword/timestamp/log rules | `GITHUB_TOKEN` only |
+| `llm` or `auto` | `agent.mode` + LLM settings | OpenAI-compatible model via Actions scripts | `TIER1_LLM_API_KEY` (+ optional base URL/model) |
+| `gh-aw` | `agent.mode: "gh-aw"` | GitHub Agentic Workflows coding agent | Copilot org billing or `COPILOT_GITHUB_TOKEN` |
+
+```json
+{
+  "agent": {
+    "mode": "auto",
+    "llm": {
+      "base_url": "https://api.openai.com/v1",
+      "model": "gpt-4o-mini",
+      "api_key_env": "TIER1_LLM_API_KEY",
+      "api_style": "openai"
+    }
+  }
+}
+```
+
+- **`auto`** — use LLM when `TIER1_LLM_API_KEY` (or env named in `api_key_env`) is set; otherwise heuristic.  
+- **`llm`** — always attempt LLM; fall back to heuristic on API failure.  
+- **`gh-aw`** — Actions Node jobs **skip**; run compiled workflows from [`gh-aw/`](gh-aw/).  
+### Azure OpenAI / APIM
+
+**Native Azure:**
+
+```json
+"agent": {
+  "mode": "auto",
+  "llm": {
+    "api_style": "azure",
+    "base_url": "https://YOUR_RESOURCE.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT",
+    "api_version": "2025-04-01-preview",
+    "api_key_env": "TIER1_LLM_API_KEY"
+  }
+}
+```
+
+**APIM front door** (subscription key) — use `azure-apim` (auto if host is `*.azure-api.net`):
+
+```json
+"agent": {
+  "mode": "auto",
+  "llm": {
+    "api_style": "azure-apim",
+    "base_url": "https://YOUR_APIM.azure-api.net/YOUR_PRODUCT/openai/deployments/YOUR_DEPLOYMENT",
+    "api_version": "2025-04-01-preview",
+    "api_key_env": "TIER1_LLM_API_KEY"
+  }
+}
+```
+
+`base_url` must include `/openai/deployments/{deployment-name}` (no trailing slash). APIM auth uses `Ocp-Apim-Subscription-Key`.
+
+## Repo secrets / variables
+
+| Name | Used by |
+| --- | --- |
+| `TIER1_LLM_API_KEY` | Azure / OpenAI API key |
+| `TIER1_LLM_BASE_URL` | optional override of `agent.llm.base_url` |
+| `TIER1_LLM_MODEL` | optional (ignored for Azure; deployment is in the URL) |
+| `TIER1_LLM_API_STYLE` | optional Actions var: `azure` |
+| `TIER1_LLM_API_VERSION` | optional Actions var (default `2024-08-01-preview`) |
+| `COPILOT_GITHUB_TOKEN` | gh-aw on personal repos / without org billing |
+
+## Avoid double agents
+
+Do not run LLM Actions **and** gh-aw on the same event with both writing comments. Pick one mode in `tier1.config.json`.

--- a/.github/tier1/ENROL.md
+++ b/.github/tier1/ENROL.md
@@ -1,0 +1,85 @@
+# Enrol Tier 1 (external teams)
+
+**Goal:** an afternoon to get issue triage, docs drift, and CI diagnosis in *your* repo.
+
+## Prerequisites
+
+See **[YOU-PROVIDE.md](YOU-PROVIDE.md)** — GitHub access, Actions enabled, and (for a test) a disposable repo.
+
+## 5-minute enrol
+
+From a clone of this pattern repo (or `ai-sdlc`):
+
+```bash
+# Create / clone your consumer repo first, then:
+chmod +x patterns/tier1/enrol.sh
+./patterns/tier1/enrol.sh /path/to/your-test-repo
+
+cd /path/to/your-test-repo
+# Edit project name + paths
+${EDITOR:-nano} tier1.config.json
+
+git add .
+git commit -m "chore: enrol Tier 1 automation"
+git push -u origin HEAD
+```
+
+Or start from the scaffold:
+
+```bash
+cp -R patterns/tier1-example /path/to/tier1-test
+cd /path/to/tier1-test
+# enrol already applied; still safe to re-run:
+../tier1/enrol.sh .
+```
+
+## After push
+
+1. **GitHub → Settings → Actions → General** — allow Actions; allow read/write for workflows if asked (`GITHUB_TOKEN` workflow permissions → Read and write).
+2. **Actions** tab → run **Tier 1 / Preflight** (workflow_dispatch). Must be green.
+3. Edit **Tier 1 / CI diagnose** workflow: under `on.workflow_run.workflows`, add the exact `name:` string of your real CI workflow (demo fail is already listed).
+
+## Try each workflow
+
+| Workflow | How to test |
+| --- | --- |
+| Issue triage | Open an issue titled `bug: something broken` with a 1-line body → expect `bug` + `needs-detail` + bot comment |
+| CI diagnose | Actions → **Tier 1 / Demo fail CI** → Run → wait for **Tier 1 / CI diagnose** to open an issue/PR comment |
+| Docs drift | Commit a change only under `src/` with no doc update → Actions → **Tier 1 / Docs drift** → Run → expect draft PR or issue |
+
+## Config
+
+`tier1.config.json` at repo root (see `tier1.config.example.json`).
+
+### Agent backends (where the agent is)
+
+See **[AGENTIC.md](AGENTIC.md)**.
+
+| Mode | Enrol | Secrets |
+| --- | --- | --- |
+| `heuristic` / `auto` without key | default | none |
+| `auto` / `llm` | set secret `TIER1_LLM_API_KEY` | OpenAI-compatible (or Azure) |
+| `gh-aw` | `./enrol.sh REPO --with-gh-aw` then `gh aw compile` | Copilot org billing or `COPILOT_GITHUB_TOKEN` |
+
+```bash
+# LLM path
+gh secret set TIER1_LLM_API_KEY --body "$OPENAI_API_KEY" --repo YOU/YOUR-REPO
+# optional: gh secret set TIER1_LLM_BASE_URL --body "https://your-gateway/v1"
+
+# gh-aw path
+./enrol.sh /path/to/repo --with-gh-aw
+cd /path/to/repo
+# set agent.mode to "gh-aw" in tier1.config.json
+gh extension install github/gh-aw
+gh aw compile
+git add .github/workflows/tier1-*.md .github/workflows/tier1-*.lock.yml tier1.config.json
+git commit -m "chore(tier1): gh-aw agents" && git push
+```
+
+## Day-to-day
+
+After enrol, use **[OPERATE.md](OPERATE.md)** — roles, weekly rhythm, config knobs, troubleshooting.
+
+## Support
+
+If preflight fails, paste the job log into an issue on the pattern repo. Do not disable workflows to greenwash CI.

--- a/.github/tier1/ENROLLED.md
+++ b/.github/tier1/ENROLLED.md
@@ -1,0 +1,14 @@
+# Tier 1 enrolled
+
+Pack source: patterns/tier1
+Enrolled at: 2026-08-11T22:55:28Z
+gh-aw sources: false
+
+Next:
+1. Edit `tier1.config.json` — `project` and `agent.mode` (`auto` | `heuristic` | `llm` | `gh-aw`).
+2. For LLM: add repo secret `TIER1_LLM_API_KEY` (see .github/tier1/AGENTIC.md).
+3. For gh-aw: `gh extension install github/gh-aw && gh aw compile`, commit `*.lock.yml`, set mode `gh-aw`.
+4. Push; enable Actions; workflow permissions Read and write.
+5. Run **Tier 1 / Preflight**.
+6. Test triage / demo-fail / docs-drift.
+7. Day-to-day ops: `.github/tier1/OPERATE.md`.

--- a/.github/tier1/OPERATE.md
+++ b/.github/tier1/OPERATE.md
@@ -1,0 +1,123 @@
+# Operate Tier 1
+
+Human playbook for **day-to-day use** of the Tier 1 pattern after enrol.  
+For first-time setup see [ENROL.md](ENROL.md). For backends and secrets see [AGENTIC.md](AGENTIC.md).
+
+**What Tier 1 is:** lightweight repo automation — issue triage, docs-drift nudges, and CI failure diagnosis. It does **not** implement features or run Spec Kit checkpoints (that’s Tier 2).
+
+---
+
+## Who does what
+
+| Role | Responsibilities |
+| --- | --- |
+| **Repo maintainers** | Own `tier1.config.json`, Actions permissions, secrets, which CI workflows diagnose watches |
+| **Developers** | Write usable issue bodies; respond to `needs-detail`; keep docs in sync with code when drift PRs open |
+| **Platform / pattern owners** | Pack updates, enrol support, org policy (Actions, Copilot billing for gh-aw) |
+
+---
+
+## What runs (and when)
+
+| Workflow | Trigger | What you should see |
+| --- | --- | --- |
+| **Issue triage** | Issue opened / edited | Labels (`bug`, `enhancement`, …) and a bot comment when the body is thin (`needs-detail`) |
+| **Docs drift** | Schedule or manual (and/or pushes touching code paths) | Draft PR or issue when `src/` (etc.) changed without `docs/` / README |
+| **CI diagnose** | Another workflow **fails** (via `workflow_run`) | Comment on the failed run / related issue with a short diagnosis |
+| **Preflight** | Manual (`workflow_dispatch`) | Green check that scripts + config + labels look sane |
+| **Demo fail CI** | Manual | Intentional failure so you can test CI diagnose |
+
+Workflow files live under `.github/workflows/tier1-*.yml` (and optional `tier1-*.lock.yml` if using gh-aw).
+
+---
+
+## Normal weekly rhythm
+
+1. **Monday (or after pack updates)** — Run **Tier 1 / Preflight**. Fix anything red before trusting triage.
+2. **Issues** — Prefer problem / expected / actual / steps. Thin issues get `needs-detail`; that’s working as designed.
+3. **Docs drift PRs** — Review like any draft PR: accept the doc update, adjust paths in config, or close with a reason if the change was intentional noise.
+4. **Failed CI** — Read the diagnose comment first; it won’t always be right, but it should point at the failing job/log slice faster.
+5. **Config tweaks** — Edit `tier1.config.json` on a branch; no re-enrol needed for path lists, labels rules, or enabling/disabling a capability.
+
+---
+
+## Config you’ll actually touch
+
+Root file: **`tier1.config.json`**.
+
+| Knob | Typical use |
+| --- | --- |
+| `project` | Display name in comments |
+| `agent.mode` | `heuristic` (default-safe) · `auto` (LLM if secret present) · `llm` · `gh-aw` |
+| `triage.enabled` / `docs_drift.enabled` / `ci_diagnose.enabled` | Soft off without deleting workflows |
+| `triage.min_body_length` / `label_rules` | Tune how strict / how labels map |
+| `docs_drift.doc_paths` / `code_paths` | Match *your* tree (`apps/` vs `src/`) |
+| `ci_diagnose.ignore_workflows` | Don’t diagnose Tier 1 itself; add other noisy workflows by **exact** `name:` |
+
+Details and Azure/APIM shapes: [AGENTIC.md](AGENTIC.md).
+
+### Switching agent backends (stay on one)
+
+| Goal | Steps |
+| --- | --- |
+| Stay on keywords only | `agent.mode`: `heuristic` — no LLM secret needed |
+| Richer comments via Actions LLM | Set secret `TIER1_LLM_API_KEY` (+ optional URL/style vars); `agent.mode`: `auto` or `llm` |
+| Copilot CLI via gh-aw | Enrol/copy gh-aw sources, `gh aw compile`, commit locks, `agent.mode`: `gh-aw` |
+
+**Rule:** pick **one** writer per event. If both Actions LLM jobs and gh-aw lock workflows comment on the same issues/PRs, you’ll get double noise. Prefer a single mode in config and align the files you keep enabled with that choice.
+
+---
+
+## Soft-disable a capability
+
+Set the matching `*.enabled` flag to `false` in `tier1.config.json` and push. Workflows may still appear in the Actions tab; jobs should no-op or skip meaningful work. Use this for a noisy docs-drift path or a temporary CI diagnose pause.
+
+---
+
+## First-week checklist (after enrol)
+
+- [ ] Actions: workflow permissions **Read and write**
+- [ ] **Preflight** green
+- [ ] Open a thin test issue → expect `needs-detail` (+ labels)
+- [ ] Run **Demo fail CI** → expect **CI diagnose** to react
+- [ ] Touch only `src/` (or your `code_paths`) → run **Docs drift** → expect draft PR or issue
+- [ ] Point CI diagnose at your **real** CI workflow `name:` (edit the diagnose workflow’s `workflow_run.workflows` list)
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | What to try |
+| --- | --- | --- |
+| Workflows never run | Actions disabled / org policy | Settings → Actions; check org allowlists |
+| Triage can’t label | `GITHUB_TOKEN` read-only | Workflow permissions → Read and write |
+| CI diagnose silent | Wrong workflow **name** in `on.workflow_run` | Copy the exact `name:` from the failing workflow YAML |
+| Docs drift always / never | `code_paths` / `doc_paths` don’t match repo layout | Edit config; re-run docs drift |
+| LLM path falls back to heuristic | Missing/wrong `TIER1_LLM_API_KEY` or APIM network block | Check secrets/vars; see wiki status on APIM |
+| Duplicate comments | Actions + gh-aw both active | One mode only — see AGENTIC.md |
+| Preflight wants labels | Labels not created yet | Let preflight/`ensureLabel` create them, or apply `.github/tier1/labels.yml` |
+
+Live org blockers (APIM, Copilot billing): see the pattern monorepo wiki page `wiki/synthesis/bcgov-pattern-packs.md` (or ask platform).
+
+---
+
+## Updating the pack
+
+From the pattern source repo:
+
+```bash
+./patterns/tier1/enrol.sh /path/to/your-service [--with-gh-aw]
+```
+
+Re-enrol **overwrites** workflows and scripts but **keeps** an existing `tier1.config.json`. Re-read the diff before push. After gh-aw source edits: `gh aw compile` and commit new locks.
+
+---
+
+## Related docs
+
+| Doc | Use when |
+| --- | --- |
+| [ENROL.md](ENROL.md) | First install |
+| [YOU-PROVIDE.md](YOU-PROVIDE.md) | Prerequisites checklist (pattern source; may not be copied) |
+| [AGENTIC.md](AGENTIC.md) | Modes, secrets, Azure/APIM, gh-aw |
+| Tier 2 operate | Spec-driven delivery — `.github/tier2/OPERATE.md` if enrolled with Tier 2 |

--- a/.github/tier1/labels.yml
+++ b/.github/tier1/labels.yml
@@ -1,0 +1,28 @@
+# Apply with: gh label import (or create via preflight script)
+- name: needs-triage
+  color: "FBCA04"
+  description: Tier 1 — awaiting classification
+- name: needs-detail
+  color: "D93F0B"
+  description: Tier 1 — issue body too thin
+- name: bug
+  color: "D73A4A"
+  description: Something isn't working
+- name: enhancement
+  color: "A2EEEF"
+  description: New feature or request
+- name: documentation
+  color: "0075CA"
+  description: Docs improvements
+- name: security
+  color: "B60205"
+  description: Security-related
+- name: accessibility
+  color: "5319E7"
+  description: Accessibility / WCAG
+- name: ops
+  color: "0E8A16"
+  description: Deploy / pipeline / operations
+- name: tier1-docs-drift
+  color: "C5DEF5"
+  description: Docs may be behind code

--- a/.github/tier1/scripts/ci-diagnose.mjs
+++ b/.github/tier1/scripts/ci-diagnose.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * CI failure diagnosis — heuristic and/or LLM.
+ * Skips when agent.mode=gh-aw.
+ */
+import { loadConfig, repoRoot } from "./lib/config.mjs";
+import { gh } from "./lib/gh.mjs";
+import { resolveAgentMode, skipIfGhAw } from "./lib/agent-mode.mjs";
+import { chatCompletion } from "./lib/llm.mjs";
+
+function arg(name) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i === -1 ? undefined : process.argv[i + 1];
+}
+
+const root = repoRoot();
+const cfg = loadConfig(root);
+if (!cfg.ci_diagnose?.enabled) {
+  console.log("ci_diagnose disabled");
+  process.exit(0);
+}
+
+const mode = resolveAgentMode(cfg);
+console.log(`agent.mode resolved: ${mode}`);
+if (skipIfGhAw(mode, "ci diagnose")) process.exit(0);
+
+const runId = process.env.RUN_ID || arg("run-id");
+const workflowName = process.env.WORKFLOW_NAME || "";
+const runUrl = process.env.RUN_URL || "";
+const headSha = process.env.HEAD_SHA || "";
+
+if (!runId) {
+  console.error("RUN_ID required");
+  process.exit(1);
+}
+
+const ignore = new Set(cfg.ci_diagnose.ignore_workflows || []);
+if (ignore.has(workflowName)) {
+  console.log(`Ignoring workflow: ${workflowName}`);
+  process.exit(0);
+}
+
+let logText = "";
+try {
+  logText = gh(["run", "view", String(runId), "--log-failed"]);
+} catch (err) {
+  logText = `Could not fetch failed logs: ${err.message}`;
+}
+
+const max = cfg.ci_diagnose.max_log_chars ?? 12000;
+if (logText.length > max) logText = logText.slice(-max);
+
+const findings = analyze(logText);
+const project = cfg.project || "repo";
+let source = "heuristic";
+let narrative = heuristicNarrative(findings);
+
+if (mode === "llm") {
+  const llmText = await llmDiagnose(cfg, { workflowName, runUrl, headSha, logText, findings });
+  if (llmText) {
+    narrative = llmText;
+    source = "llm";
+  } else {
+    console.warn("LLM diagnose failed — using heuristic");
+  }
+}
+
+const body = [
+  `### Tier 1 CI diagnosis (${project}) · \`${source}\``,
+  "",
+  `| | |`,
+  `| --- | --- |`,
+  `| Workflow | ${workflowName || "unknown"} |`,
+  `| Run | ${runUrl || runId} |`,
+  `| SHA | \`${headSha || "n/a"}\` |`,
+  "",
+  narrative,
+  "",
+  "<details><summary>Failed log excerpt (truncated)</summary>",
+  "",
+  "```",
+  logText.slice(-4000),
+  "```",
+  "",
+  "</details>",
+  "",
+  `_Tier 1 · mode=${mode} · source=${source}_`,
+].join("\n");
+
+let commented = false;
+if (headSha) {
+  try {
+    const prs = JSON.parse(
+      gh(["pr", "list", "--state", "open", "--json", "number,headRefOid,url"]),
+    );
+    const pr = prs.find((p) => p.headRefOid === headSha);
+    if (pr) {
+      gh(["pr", "comment", String(pr.number), "--body", body]);
+      console.log("Commented on PR", pr.number);
+      commented = true;
+    }
+  } catch (err) {
+    console.warn("PR comment failed:", err.message);
+  }
+}
+
+if (!commented) {
+  const title = `Tier 1: CI failed — ${workflowName || "workflow"} (#${runId})`;
+  gh(["issue", "create", "--title", title, "--body", body]);
+  console.log("Opened diagnosis issue");
+}
+
+function heuristicNarrative(findings) {
+  const lines = [
+    "## Likely causes",
+    "",
+    ...(findings.length
+      ? findings.map((f, i) => `${i + 1}. **${f.title}** — ${f.detail}`)
+      : ["1. No common pattern matched — inspect the log excerpt below."]),
+    "",
+    "## Suggested next steps",
+    "",
+    ...(findings.flatMap((f) => f.steps.map((s) => `- ${s}`)).slice(0, 8).length
+      ? findings.flatMap((f) => f.steps.map((s) => `- ${s}`)).slice(0, 8)
+      : [
+          "- Open the failed job log and jump to the first `Error` / `FAIL` line.",
+          "- Re-run locally with the same Node/OS as the workflow.",
+        ]),
+  ];
+  return lines.join("\n");
+}
+
+async function llmDiagnose(cfg, ctx) {
+  const system = `You are a CI failure analyst for a government digital service repo.
+Write concise GitHub-flavored markdown with sections:
+## Likely causes
+## Suggested next steps
+Be specific to the log. Do not invent files that are not evidenced. Max ~400 words.`;
+
+  const user = [
+    `Workflow: ${ctx.workflowName}`,
+    `Run: ${ctx.runUrl}`,
+    `SHA: ${ctx.headSha}`,
+    `Heuristic hits: ${JSON.stringify(ctx.findings)}`,
+    "",
+    "Failed log:",
+    ctx.logText.slice(-8000),
+  ].join("\n");
+
+  return chatCompletion(cfg, system, user, { json: false });
+}
+
+function analyze(log) {
+  const L = log.toLowerCase();
+  const out = [];
+  const add = (title, detail, steps) => out.push({ title, detail, steps });
+
+  if (/npm err!|yarn error|pnpm.*err|err_pnpm/.test(L)) {
+    add("Package install / npm error", "Dependency install or script failed.", [
+      "Delete lockfile mismatch locally; run the same package manager as CI.",
+      "Check Node version against `.nvmrc` / `engines` in package.json.",
+    ]);
+  }
+  if (/cannot find module|module not found|err_module_not_found/.test(L)) {
+    add("Missing module", "A required package or file path was not found.", [
+      "Confirm the import path and that the dependency is in package.json.",
+    ]);
+  }
+  if (/test failed|failing tests|assertionerror|expected .* received|× |✕ /.test(L)) {
+    add("Test failure", "One or more automated tests failed.", [
+      "Run the same test command locally.",
+      "Check for flake vs real regression on the changed files.",
+    ]);
+  }
+  if (/eslint|prettier|tsc\b|type error|failed to compile/.test(L)) {
+    add("Lint / typecheck", "Static analysis rejected the change.", [
+      "Run lint/typecheck locally and fix reported files.",
+    ]);
+  }
+  if (/permission denied|access denied|403|resource not accessible by integration/.test(L)) {
+    add("Permissions", "Token or org policy blocked an API/file operation.", [
+      "Check workflow `permissions:` and org Actions settings.",
+    ]);
+  }
+  if (/enoent|no such file|pathspec/.test(L)) {
+    add("Missing file/path", "A path referenced by the workflow does not exist.", [
+      "Verify working-directory and paths in the workflow YAML.",
+    ]);
+  }
+  if (/docker|buildx|image/.test(L) && /error|failed/.test(L)) {
+    add("Container build", "Docker/image build step failed.", [
+      "Build the image locally with the same Dockerfile args.",
+    ]);
+  }
+  if (/intentional failure for tier 1/i.test(log)) {
+    add("Demo failure", "This is the Tier 1 demo-fail workflow.", [
+      "No product fix needed — used to validate CI diagnose.",
+    ]);
+  }
+  return out;
+}

--- a/.github/tier1/scripts/docs-drift.mjs
+++ b/.github/tier1/scripts/docs-drift.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+/**
+ * Detect when code paths have newer commits than doc paths; write a report
+ * and optionally open a draft PR. Optional LLM section drafts doc update hints.
+ * Skips when agent.mode=gh-aw.
+ */
+import { existsSync, mkdirSync, writeFileSync, statSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { loadConfig, repoRoot } from "./lib/config.mjs";
+import { ensureLabel, gh } from "./lib/gh.mjs";
+import { resolveAgentMode, skipIfGhAw } from "./lib/agent-mode.mjs";
+import { chatCompletion } from "./lib/llm.mjs";
+
+function git(args, root) {
+  return execFileSync("git", args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function listFiles(root, rel) {
+  const abs = path.join(root, rel);
+  if (!existsSync(abs)) return [];
+  const st = statSync(abs);
+  if (st.isFile()) return [rel.replace(/\\/g, "/")];
+  const out = [];
+  const walk = (dir, prefix) => {
+    for (const name of readdirSync(dir)) {
+      if (name === "node_modules" || name === ".git") continue;
+      const p = path.join(dir, name);
+      const relPath = path.join(prefix, name).replace(/\\/g, "/");
+      if (statSync(p).isDirectory()) walk(p, relPath);
+      else out.push(relPath);
+    }
+  };
+  walk(abs, rel.replace(/\/$/, ""));
+  return out;
+}
+
+function latestCommitTs(root, files) {
+  if (!files.length) return 0;
+  // git log -1 --format=%ct -- <files>
+  try {
+    const out = git(["log", "-1", "--format=%ct", "--", ...files], root);
+    return out ? Number(out) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+const root = repoRoot();
+const cfg = loadConfig(root);
+if (!cfg.docs_drift?.enabled) {
+  console.log("docs_drift disabled");
+  process.exit(0);
+}
+
+const mode = resolveAgentMode(cfg);
+console.log(`agent.mode resolved: ${mode}`);
+if (skipIfGhAw(mode, "docs drift")) process.exit(0);
+
+const docFiles = (cfg.docs_drift.doc_paths || []).flatMap((p) => listFiles(root, p));
+const codeFiles = (cfg.docs_drift.code_paths || []).flatMap((p) => listFiles(root, p));
+
+if (!codeFiles.length) {
+  console.log("No code files under code_paths — skip");
+  process.exit(0);
+}
+
+const docTs = latestCommitTs(root, docFiles.length ? docFiles : ["README.md"]);
+const codeTs = latestCommitTs(root, codeFiles);
+
+const drift = codeTs > docTs + 60; // code commit newer than docs by >60s
+const reportPath = cfg.docs_drift.report_path || "docs/tier1-docs-drift-report.md";
+const dryRun = process.argv.includes("--dry-run");
+
+let agentSection = "";
+let source = "heuristic";
+if (drift && mode === "llm") {
+  const llmHints = await llmDocHints(cfg, root, codeFiles, docFiles);
+  if (llmHints) {
+    agentSection = ["", "## Agent-suggested doc updates", "", llmHints, ""].join("\n");
+    source = "llm";
+  }
+}
+
+const report = [
+  `# Docs drift report`,
+  "",
+  `Project: **${cfg.project || "repo"}**`,
+  `Generated: ${new Date().toISOString()}`,
+  `Mode: \`${mode}\` · source: \`${source}\``,
+  "",
+  `| Signal | Value |`,
+  `| --- | --- |`,
+  `| Code paths | ${(cfg.docs_drift.code_paths || []).join(", ")} |`,
+  `| Doc paths | ${(cfg.docs_drift.doc_paths || []).join(", ")} |`,
+  `| Latest code commit (unix) | ${codeTs || "n/a"} |`,
+  `| Latest docs commit (unix) | ${docTs || "n/a"} |`,
+  `| Drift detected | ${drift ? "YES" : "no"} |`,
+  "",
+  "## What to do",
+  "",
+  "1. Review recent changes under code paths.",
+  "2. Update README/docs to match public behaviour.",
+  "3. Merge this report PR or close after docs are updated.",
+  agentSection,
+  "## Recent code files (sample)",
+  "",
+  ...codeFiles.slice(0, 40).map((f) => `- \`${f}\``),
+  "",
+  "_Tier 1 — timestamp drift detection; LLM section is advisory only._",
+  "",
+].join("\n");
+
+async function llmDocHints(cfg, root, codeFiles, docFiles) {
+  const samples = [];
+  for (const f of codeFiles.slice(0, 5)) {
+    try {
+      const text = readFileSync(path.join(root, f), "utf8").slice(0, 1500);
+      samples.push(`### ${f}\n\`\`\`\n${text}\n\`\`\``);
+    } catch {
+      /* skip */
+    }
+  }
+  const docSample = docFiles.slice(0, 3).map((f) => {
+    try {
+      return `### ${f}\n${readFileSync(path.join(root, f), "utf8").slice(0, 1200)}`;
+    } catch {
+      return `### ${f}\n(unreadable)`;
+    }
+  });
+
+  const system = `You help keep docs aligned with code. Suggest concrete doc edits in markdown.
+Do not invent APIs not visible in the code samples. Keep under 350 words.`;
+  const user = ["Code samples:", ...samples, "", "Current docs:", ...docSample].join("\n");
+  return chatCompletion(cfg, system, user);
+}
+
+console.log(report);
+
+if (!drift) {
+  console.log("No drift — exiting 0");
+  process.exit(0);
+}
+
+if (dryRun) {
+  console.log("Dry run — not opening PR/issue");
+  process.exit(0);
+}
+
+mkdirSync(path.dirname(path.join(root, reportPath)), { recursive: true });
+writeFileSync(path.join(root, reportPath), report);
+
+if (cfg.docs_drift.open_pull_request) {
+  const branch = `tier1/docs-drift-${new Date().toISOString().slice(0, 10).replace(/-/g, "")}`;
+  try {
+    git(["checkout", "-B", branch], root);
+    git(["add", reportPath], root);
+    git(
+      [
+        "commit",
+        "-m",
+        "chore(tier1): docs drift report",
+        "-m",
+        "Automated Tier 1 docs drift detection. Update docs and close.",
+      ],
+      root,
+    );
+    git(["push", "-u", "origin", branch, "--force"], root);
+    ensureLabel("tier1-docs-drift", "C5DEF5", "Docs may be behind code");
+    const url = gh([
+      "pr",
+      "create",
+      "--draft",
+      "--title",
+      "chore(tier1): docs may have drifted from code",
+      "--body",
+      [
+        "Tier 1 docs-drift workflow detected **code commits newer than docs**.",
+        "",
+        `See \`${reportPath}\`.`,
+        "",
+        "Please update documentation or explain why no doc change is needed, then close this PR.",
+      ].join("\n"),
+      "--label",
+      "tier1-docs-drift",
+    ]);
+    console.log("Opened PR:", url);
+  } catch (err) {
+    console.error("PR path failed, falling back to issue:", err.message);
+    ensureLabel("tier1-docs-drift", "C5DEF5");
+    gh([
+      "issue",
+      "create",
+      "--title",
+      "Tier 1: docs may have drifted from code",
+      "--body",
+      report,
+      "--label",
+      "tier1-docs-drift",
+    ]);
+  }
+} else {
+  ensureLabel("tier1-docs-drift", "C5DEF5");
+  gh([
+    "issue",
+    "create",
+    "--title",
+    "Tier 1: docs may have drifted from code",
+    "--body",
+    report,
+    "--label",
+    "tier1-docs-drift",
+  ]);
+}

--- a/.github/tier1/scripts/lib/agent-mode.mjs
+++ b/.github/tier1/scripts/lib/agent-mode.mjs
@@ -1,0 +1,34 @@
+/**
+ * Resolve Tier 1 agent backend.
+ * Modes: heuristic | llm | gh-aw | auto
+ *   auto → llm if API key present, else heuristic
+ */
+export function resolveAgentMode(cfg) {
+  const configured = (cfg.agent?.mode || process.env.TIER1_AGENT_MODE || "heuristic")
+    .toString()
+    .toLowerCase();
+
+  if (configured === "gh-aw" || configured === "ghaw") return "gh-aw";
+  if (configured === "heuristic" || configured === "rules") return "heuristic";
+  if (configured === "llm") return "llm";
+
+  // auto
+  if (hasLlmCredentials(cfg)) return "llm";
+  return "heuristic";
+}
+
+export function hasLlmCredentials(cfg) {
+  const keyEnv = cfg.agent?.llm?.api_key_env || "TIER1_LLM_API_KEY";
+  const key = process.env[keyEnv] || process.env.TIER1_LLM_API_KEY || process.env.OPENAI_API_KEY;
+  return Boolean(key && String(key).trim());
+}
+
+export function skipIfGhAw(mode, jobName) {
+  if (mode === "gh-aw") {
+    console.log(
+      `Skipping Actions job "${jobName}" — agent.mode is gh-aw. Use compiled .lock.yml workflows from gh-aw/*.md`,
+    );
+    return true;
+  }
+  return false;
+}

--- a/.github/tier1/scripts/lib/config.mjs
+++ b/.github/tier1/scripts/lib/config.mjs
@@ -1,0 +1,20 @@
+import { readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+
+export function loadConfig(root = process.cwd()) {
+  const jsonPath = path.join(root, "tier1.config.json");
+  if (!existsSync(jsonPath)) {
+    throw new Error(
+      `Missing ${jsonPath}. Copy patterns/tier1/tier1.config.example.json → tier1.config.json (see ENROL.md).`,
+    );
+  }
+  const cfg = JSON.parse(readFileSync(jsonPath, "utf8"));
+  if (cfg.version !== 1) {
+    throw new Error(`Unsupported tier1.config.json version: ${cfg.version}`);
+  }
+  return cfg;
+}
+
+export function repoRoot() {
+  return process.env.GITHUB_WORKSPACE || process.env.TIER1_ROOT || process.cwd();
+}

--- a/.github/tier1/scripts/lib/gh.mjs
+++ b/.github/tier1/scripts/lib/gh.mjs
@@ -1,0 +1,41 @@
+import { execFileSync } from "node:child_process";
+
+export function gh(args, { input, ignoreError = false } = {}) {
+  try {
+    return execFileSync("gh", args, {
+      encoding: "utf8",
+      input,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: process.env,
+    }).trim();
+  } catch (err) {
+    if (ignoreError) return "";
+    const stderr = err.stderr?.toString?.() || err.message;
+    throw new Error(`gh ${args.join(" ")} failed: ${stderr}`);
+  }
+}
+
+export function ensureLabel(name, color = "CCCCCC", description = "") {
+  const list = gh(["label", "list", "--json", "name"], { ignoreError: true });
+  if (list) {
+    try {
+      const names = JSON.parse(list).map((l) => l.name);
+      if (names.includes(name)) return;
+    } catch {
+      /* create below */
+    }
+  }
+  gh(
+    [
+      "label",
+      "create",
+      name,
+      "--color",
+      color.replace(/^#/, ""),
+      "--description",
+      description || name,
+      "--force",
+    ],
+    { ignoreError: true },
+  );
+}

--- a/.github/tier1/scripts/lib/llm.mjs
+++ b/.github/tier1/scripts/lib/llm.mjs
@@ -1,0 +1,142 @@
+/**
+ * OpenAI-compatible Chat Completions client (Azure OpenAI / APIM / OpenAI).
+ *
+ * Azure / APIM base_url form:
+ *   https://{host}/{product}/openai/deployments/{deployment}
+ * Auth:
+ *   api_style "azure"     → header api-key (native Azure OpenAI)
+ *   api_style "azure-apim"→ header Ocp-Apim-Subscription-Key (+ api-key mirror)
+ */
+
+export function llmConfigFrom(cfg) {
+  const llm = cfg.agent?.llm || {};
+  const keyEnv = llm.api_key_env || "TIER1_LLM_API_KEY";
+  const apiKey =
+    process.env[keyEnv] ||
+    process.env.TIER1_LLM_API_KEY ||
+    process.env.AZURE_OPENAI_API_KEY ||
+    process.env.OPENAI_API_KEY ||
+    "";
+
+  let baseUrl = (
+    process.env.TIER1_LLM_BASE_URL ||
+    llm.base_url ||
+    buildAzureBaseFromEnv() ||
+    "https://api.openai.com/v1"
+  ).replace(/\/$/, "");
+
+  const model =
+    process.env.TIER1_LLM_MODEL ||
+    process.env.AZURE_OPENAI_DEPLOYMENT ||
+    llm.model ||
+    "gpt-4o-mini";
+
+  let apiStyle = (llm.api_style || process.env.TIER1_LLM_API_STYLE || "openai").toLowerCase();
+  if (apiStyle === "azure" && /azure-api\.net/i.test(baseUrl)) {
+    apiStyle = "azure-apim";
+  }
+
+  const apiVersion =
+    llm.api_version ||
+    process.env.TIER1_LLM_API_VERSION ||
+    process.env.AZURE_OPENAI_API_VERSION ||
+    "2024-08-01-preview";
+
+  return { apiKey, baseUrl, model, apiStyle, apiVersion, llm };
+}
+
+function buildAzureBaseFromEnv() {
+  const endpoint = (process.env.AZURE_OPENAI_ENDPOINT || "").replace(/\/$/, "");
+  const deployment = process.env.AZURE_OPENAI_DEPLOYMENT || "";
+  if (!endpoint || !deployment) return "";
+  // If endpoint already includes /openai/deployments/..., use as-is
+  if (/\/openai\/deployments\//i.test(endpoint)) return endpoint;
+  return `${endpoint}/openai/deployments/${deployment}`;
+}
+
+/**
+ * @param {object} cfg tier1/tier2 config
+ * @param {string} system
+ * @param {string} user
+ * @param {{ json?: boolean }} opts
+ * @returns {Promise<string|null>} null on failure
+ */
+export async function chatCompletion(cfg, system, user, opts = {}) {
+  const { apiKey, baseUrl, model, apiStyle, apiVersion, llm } = llmConfigFrom(cfg);
+  if (!apiKey) {
+    console.warn("LLM: no API key — falling back");
+    return null;
+  }
+
+  let url = `${baseUrl}/chat/completions`;
+  const headers = {
+    "Content-Type": "application/json",
+  };
+
+  const isAzure = apiStyle === "azure" || apiStyle === "azure-apim";
+
+  if (isAzure) {
+    url = `${baseUrl}/chat/completions?api-version=${encodeURIComponent(apiVersion)}`;
+    if (apiStyle === "azure-apim") {
+      headers["Ocp-Apim-Subscription-Key"] = apiKey;
+      headers["api-key"] = apiKey; // some APIM policies forward api-key
+    } else {
+      headers["api-key"] = apiKey;
+    }
+  } else {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
+  const body = {
+    messages: [
+      { role: "system", content: system },
+      { role: "user", content: user },
+    ],
+  };
+
+  // Some newer models reject temperature; only set when configured
+  if (llm.temperature !== undefined && llm.temperature !== null) {
+    body.temperature = llm.temperature;
+  } else if (!isAzure) {
+    body.temperature = 0.2;
+  }
+
+  if (!isAzure) body.model = model;
+  if (opts.json) {
+    body.response_format = { type: "json_object" };
+  }
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      console.warn(`LLM HTTP ${res.status}: ${text.slice(0, 400)}`);
+      return null;
+    }
+    const data = await res.json();
+    const content = data.choices?.[0]?.message?.content;
+    return typeof content === "string" ? content : null;
+  } catch (err) {
+    console.warn(`LLM request failed: ${err.message}`);
+    return null;
+  }
+}
+
+export function parseJsonLoose(text) {
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    const m = text.match(/\{[\s\S]*\}/);
+    if (!m) return null;
+    try {
+      return JSON.parse(m[0]);
+    } catch {
+      return null;
+    }
+  }
+}

--- a/.github/tier1/scripts/preflight.mjs
+++ b/.github/tier1/scripts/preflight.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Verify Tier 1 enrolment: config, workflows present, labels creatable.
+ */
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { loadConfig, repoRoot } from "./lib/config.mjs";
+import { ensureLabel, gh } from "./lib/gh.mjs";
+import { hasLlmCredentials, resolveAgentMode } from "./lib/agent-mode.mjs";
+
+const root = repoRoot();
+const failures = [];
+const warnings = [];
+
+function ok(msg) {
+  console.log(`PASS  ${msg}`);
+}
+function fail(msg) {
+  console.log(`FAIL  ${msg}`);
+  failures.push(msg);
+}
+function warn(msg) {
+  console.log(`WARN  ${msg}`);
+  warnings.push(msg);
+}
+
+let cfg;
+try {
+  cfg = loadConfig(root);
+  ok("tier1.config.json loaded");
+  const mode = resolveAgentMode(cfg);
+  ok(`agent.mode → ${mode} (configured: ${cfg.agent?.mode || "heuristic"})`);
+  if (mode === "llm" || cfg.agent?.mode === "auto") {
+    if (hasLlmCredentials(cfg)) ok("LLM API key present in environment");
+    else warn("No TIER1_LLM_API_KEY — auto/llm will use heuristic until secret is set");
+  }
+  if (mode === "gh-aw") {
+    const md = ["tier1-triage.md", "tier1-docs-drift.md", "tier1-ci-diagnose.md"];
+    for (const f of md) {
+      if (existsSync(path.join(root, ".github/workflows", f))) ok(`gh-aw source ${f}`);
+      else warn(`gh-aw source missing: .github/workflows/${f}`);
+      const lock = f.replace(/\.md$/, ".lock.yml");
+      if (existsSync(path.join(root, ".github/workflows", lock))) ok(`gh-aw lock ${lock}`);
+      else warn(`gh-aw lock missing: ${lock} — run gh aw compile`);
+    }
+  }
+} catch (e) {
+  fail(e.message);
+  cfg = null;
+}
+
+const requiredWorkflows = [
+  "tier1-preflight.yml",
+  "tier1-triage.yml",
+  "tier1-docs-drift.yml",
+  "tier1-ci-diagnose.yml",
+];
+for (const w of requiredWorkflows) {
+  const p = path.join(root, ".github/workflows", w);
+  if (existsSync(p)) ok(`workflow ${w}`);
+  else fail(`missing .github/workflows/${w}`);
+}
+
+const scriptsDir = path.join(root, ".github/tier1/scripts");
+const altScripts = path.join(root, "tier1/scripts");
+const scriptsRoot = existsSync(scriptsDir)
+  ? scriptsDir
+  : existsSync(altScripts)
+    ? altScripts
+    : null;
+if (scriptsRoot) ok(`scripts at ${path.relative(root, scriptsRoot)}`);
+else fail("missing Tier 1 scripts (.github/tier1/scripts or tier1/scripts)");
+
+if (cfg?.preflight?.require_labels !== false) {
+  const labels = [
+    cfg?.triage?.default_label,
+    cfg?.triage?.needs_detail_label,
+    "bug",
+    "enhancement",
+    "tier1-docs-drift",
+  ].filter(Boolean);
+  try {
+    gh(["auth", "status"]);
+    for (const name of labels) {
+      ensureLabel(name);
+    }
+    ok(`labels ensured: ${labels.join(", ")}`);
+  } catch (e) {
+    warn(`could not ensure labels via gh: ${e.message}`);
+  }
+}
+
+if (existsSync(path.join(root, "AGENTS.md"))) ok("AGENTS.md present");
+else warn("AGENTS.md missing — copy AGENTS.tier1.md → AGENTS.md");
+
+console.log("");
+console.log(`Summary: ${failures.length} fail, ${warnings.length} warn`);
+if (failures.length) process.exit(1);
+console.log("Tier 1 preflight OK");

--- a/.github/tier1/scripts/triage-issue.mjs
+++ b/.github/tier1/scripts/triage-issue.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Issue triage — heuristic and/or LLM.
+ * Env: ISSUE_NUMBER. Skips when agent.mode=gh-aw.
+ */
+import { loadConfig, repoRoot } from "./lib/config.mjs";
+import { ensureLabel, gh } from "./lib/gh.mjs";
+import { resolveAgentMode, skipIfGhAw } from "./lib/agent-mode.mjs";
+import { chatCompletion, parseJsonLoose } from "./lib/llm.mjs";
+
+function arg(name) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i === -1 ? undefined : process.argv[i + 1];
+}
+
+const root = repoRoot();
+const cfg = loadConfig(root);
+if (!cfg.triage?.enabled) {
+  console.log("triage disabled in tier1.config.json");
+  process.exit(0);
+}
+
+const mode = resolveAgentMode(cfg);
+console.log(`agent.mode resolved: ${mode}`);
+if (skipIfGhAw(mode, "issue triage")) process.exit(0);
+
+const issueNumber = arg("issue") || process.env.ISSUE_NUMBER;
+if (!issueNumber) {
+  console.error("Set ISSUE_NUMBER or --issue");
+  process.exit(1);
+}
+
+const raw = gh([
+  "issue",
+  "view",
+  String(issueNumber),
+  "--json",
+  "title,body,labels,number",
+]);
+const issue = JSON.parse(raw);
+const allowedLabels = [
+  ...(cfg.triage.label_rules || []).map((r) => r.label),
+  cfg.triage.default_label,
+  cfg.triage.needs_detail_label,
+].filter(Boolean);
+
+const heuristic = heuristicTriage(cfg, issue);
+let decision = { ...heuristic, source: "heuristic" };
+
+if (mode === "llm") {
+  const llmDecision = await llmTriage(cfg, issue, allowedLabels, heuristic);
+  if (llmDecision) decision = { ...llmDecision, source: "llm" };
+  else console.warn("LLM triage failed — using heuristic");
+}
+
+const existing = new Set((issue.labels || []).map((l) => l.name));
+const toAdd = (decision.labels || []).filter((l) => allowedLabels.includes(l) && !existing.has(l));
+
+for (const label of new Set(toAdd)) {
+  ensureLabel(label);
+  gh(["issue", "edit", String(issueNumber), "--add-label", label]);
+  console.log(`Added label: ${label}`);
+}
+
+if (decision.comment) {
+  const header = `### Tier 1 triage (${cfg.project || "repo"}) · \`${decision.source}\`\n\n`;
+  gh(["issue", "comment", String(issueNumber), "--body", header + decision.comment]);
+  console.log("Posted comment");
+}
+
+console.log(JSON.stringify({ issue: issue.number, mode, decision, labelsAdded: toAdd }, null, 2));
+
+function heuristicTriage(cfg, issue) {
+  const text = `${issue.title || ""}\n${issue.body || ""}`.toLowerCase();
+  const bodyLen = (issue.body || "").trim().length;
+  const labels = [];
+  for (const rule of cfg.triage.label_rules || []) {
+    if (text.includes(String(rule.match).toLowerCase())) labels.push(rule.label);
+  }
+  if (labels.length === 0 && cfg.triage.default_label) labels.push(cfg.triage.default_label);
+
+  const needsDetail = bodyLen < (cfg.triage.min_body_length ?? 80);
+  if (needsDetail && cfg.triage.needs_detail_label) labels.push(cfg.triage.needs_detail_label);
+
+  let comment = null;
+  if (needsDetail) {
+    comment = [
+      "Thanks for the issue. Please add enough detail for someone to act on it:",
+      "",
+      "- **Problem** — what is going wrong?",
+      "- **Expected** — what should happen?",
+      "- **Actual** — what happens instead?",
+      "- **Steps** — how to reproduce (if applicable)",
+      "",
+      `_Heuristic · body length ${bodyLen} < ${cfg.triage.min_body_length}_`,
+    ].join("\n");
+  }
+  return { labels: [...new Set(labels)], needsDetail, comment };
+}
+
+async function llmTriage(cfg, issue, allowedLabels, fallback) {
+  const system = `You triage GitHub issues for a BC Gov service repo.
+Return JSON only: {"labels":string[],"needsDetail":boolean,"comment":string|null}
+Rules:
+- labels must be chosen from: ${allowedLabels.join(", ")}
+- needsDetail true if reproduction/expected/actual are missing
+- comment: short markdown asking for missing info, or null if issue is complete
+- Prefer precision over many labels (1-3 labels)`;
+
+  const user = `Title: ${issue.title}\n\nBody:\n${issue.body || "(empty)"}\n\nHeuristic suggestion: ${JSON.stringify(fallback)}`;
+  const content = await chatCompletion(cfg, system, user, { json: true });
+  const parsed = parseJsonLoose(content);
+  if (!parsed || !Array.isArray(parsed.labels)) return null;
+  return {
+    labels: parsed.labels.filter((l) => allowedLabels.includes(l)),
+    needsDetail: Boolean(parsed.needsDetail),
+    comment: parsed.comment || (parsed.needsDetail ? fallback.comment : null),
+  };
+}

--- a/.github/workflows/tier1-ci-diagnose.yml
+++ b/.github/workflows/tier1-ci-diagnose.yml
@@ -1,0 +1,41 @@
+name: Tier 1 / CI diagnose
+
+on:
+  workflow_run:
+    # IMPORTANT: list the `name:` of CI workflows to watch (GitHub has no wildcard).
+    # Add your real pipeline names here after enrol.
+    workflows:
+      - "Tier 1 / Demo fail CI"
+      - "PR Checks"
+      - "Analysis"
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  diagnose:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Diagnose failed run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          TIER1_LLM_API_KEY: ${{ secrets.TIER1_LLM_API_KEY }}
+          TIER1_LLM_BASE_URL: ${{ secrets.TIER1_LLM_BASE_URL }}
+          TIER1_LLM_MODEL: ${{ vars.TIER1_LLM_MODEL }}
+          TIER1_LLM_API_STYLE: ${{ vars.TIER1_LLM_API_STYLE }}
+          TIER1_LLM_API_VERSION: ${{ vars.TIER1_LLM_API_VERSION }}
+        run: node .github/tier1/scripts/ci-diagnose.mjs

--- a/.github/workflows/tier1-demo-fail.yml
+++ b/.github/workflows/tier1-demo-fail.yml
@@ -1,0 +1,14 @@
+# Optional: copy into a test repo to force a CI failure and exercise CI diagnose.
+# Do NOT enable in production services.
+name: Tier 1 / Demo fail CI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  fail:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Intentional failure for Tier 1 CI diagnose demo"
+          exit 1

--- a/.github/workflows/tier1-docs-drift.yml
+++ b/.github/workflows/tier1-docs-drift.yml
@@ -1,0 +1,37 @@
+name: Tier 1 / Docs drift
+
+on:
+  schedule:
+    # Mondays 15:00 UTC
+    - cron: "0 15 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Configure git identity
+        run: |
+          git config user.name "tier1-bot"
+          git config user.email "tier1-bot@users.noreply.github.com"
+      - name: Detect docs drift
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          TIER1_LLM_API_KEY: ${{ secrets.TIER1_LLM_API_KEY }}
+          TIER1_LLM_BASE_URL: ${{ secrets.TIER1_LLM_BASE_URL }}
+          TIER1_LLM_MODEL: ${{ vars.TIER1_LLM_MODEL }}
+          TIER1_LLM_API_STYLE: ${{ vars.TIER1_LLM_API_STYLE }}
+          TIER1_LLM_API_VERSION: ${{ vars.TIER1_LLM_API_VERSION }}
+        run: node .github/tier1/scripts/docs-drift.mjs

--- a/.github/workflows/tier1-preflight.yml
+++ b/.github/workflows/tier1-preflight.yml
@@ -1,0 +1,28 @@
+name: Tier 1 / Preflight
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "tier1.config.json"
+      - ".github/workflows/tier1-*.yml"
+      - ".github/tier1/**"
+      - "AGENTS.md"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node .github/tier1/scripts/preflight.mjs

--- a/.github/workflows/tier1-triage.yml
+++ b/.github/workflows/tier1-triage.yml
@@ -1,0 +1,29 @@
+name: Tier 1 / Issue triage
+
+on:
+  issues:
+    types: [opened, reopened, edited]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Triage issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TIER1_LLM_API_KEY: ${{ secrets.TIER1_LLM_API_KEY }}
+          TIER1_LLM_BASE_URL: ${{ secrets.TIER1_LLM_BASE_URL }}
+          TIER1_LLM_MODEL: ${{ vars.TIER1_LLM_MODEL }}
+          TIER1_LLM_API_STYLE: ${{ vars.TIER1_LLM_API_STYLE }}
+          TIER1_LLM_API_VERSION: ${{ vars.TIER1_LLM_API_VERSION }}
+        run: node .github/tier1/scripts/triage-issue.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md (Tier 1)
+
+This repository uses **Tier 1** automation from the BC Gov agentic SDLC pattern:
+
+1. **Issue triage** — labels and asks for detail on thin issues
+2. **Docs drift** — periodic check that docs keep up with code
+3. **CI diagnose** — comments a diagnosis on failed workflow runs
+
+Backend is selected by `agent.mode` in `tier1.config.json`: `heuristic` | `auto` | `llm` | `gh-aw` (see `.github/tier1/AGENTIC.md`).
+
+## For coding agents
+
+- Do not disable Tier 1 workflows to “make CI green.”
+- Prefer updating `docs/` in the same PR when you change public APIs under `src/`.
+- Write issue bodies with: problem, expected, actual, steps — triage bots flag thin descriptions.
+- Configuration: `tier1.config.json` at repo root.
+
+## Upgrade path
+
+Tier 2 adds Spec Kit, constitution, Design System MCP, and human checkpoints. See the platform `bcgov-agentic-glue` bundles when you are ready.

--- a/tier1.config.json
+++ b/tier1.config.json
@@ -1,0 +1,98 @@
+{
+  "version": 1,
+  "project": "bcparks-ar-admin-agentic",
+  "agent": {
+    "mode": "heuristic",
+    "llm": {
+      "base_url": "https://api.openai.com/v1",
+      "model": "gpt-4o-mini",
+      "api_key_env": "TIER1_LLM_API_KEY",
+      "api_style": "openai",
+      "temperature": 0.2
+    }
+  },
+  "triage": {
+    "enabled": true,
+    "min_body_length": 80,
+    "label_rules": [
+      {
+        "match": "bug",
+        "label": "bug"
+      },
+      {
+        "match": "broken",
+        "label": "bug"
+      },
+      {
+        "match": "error",
+        "label": "bug"
+      },
+      {
+        "match": "feature",
+        "label": "enhancement"
+      },
+      {
+        "match": "enhance",
+        "label": "enhancement"
+      },
+      {
+        "match": "docs",
+        "label": "documentation"
+      },
+      {
+        "match": "readme",
+        "label": "documentation"
+      },
+      {
+        "match": "security",
+        "label": "security"
+      },
+      {
+        "match": "a11y",
+        "label": "accessibility"
+      },
+      {
+        "match": "accessibility",
+        "label": "accessibility"
+      },
+      {
+        "match": "deploy",
+        "label": "ops"
+      },
+      {
+        "match": "pipeline",
+        "label": "ops"
+      }
+    ],
+    "default_label": "needs-triage",
+    "needs_detail_label": "needs-detail"
+  },
+  "docs_drift": {
+    "enabled": true,
+    "doc_paths": [
+      "docs/",
+      "README.md"
+    ],
+    "code_paths": [
+      "src/"
+    ],
+    "open_pull_request": true,
+    "report_path": "docs/tier1-docs-drift-report.md"
+  },
+  "ci_diagnose": {
+    "enabled": true,
+    "ignore_workflows": [
+      "Tier 1 / Preflight",
+      "Tier 1 / Issue triage",
+      "Tier 1 / Docs drift",
+      "Tier 1 / CI diagnose",
+      "Tier 1 / Issue triage (gh-aw)",
+      "Tier 1 / Docs drift (gh-aw)",
+      "Tier 1 / CI diagnose (gh-aw)"
+    ],
+    "max_log_chars": 12000
+  },
+  "preflight": {
+    "require_labels": true
+  }
+}


### PR DESCRIPTION
## Summary
- Enrol Tier 1 pack (heuristic): issue triage, docs drift, CI diagnose, preflight, demo-fail CI
- Configure `tier1.config.json` for `bcparks-ar-admin-agentic`
- Point CI diagnose at existing workflows: **PR Checks**, **Analysis**

## Test plan
- [ ] Settings → Actions → Workflow permissions = **Read and write**
- [ ] Actions → **Tier 1 / Preflight** → Run workflow → green
- [ ] Open a thin issue (`bug: something broken` + 1-line body) → expect triage labels/comment
- [ ] Actions → **Tier 1 / Demo fail CI** → Run → expect CI diagnose comment/issue
- [ ] Optional: merge this PR to `main` once preflight is green

Pilot scope: process/CI only (no Keycloak / ar-api required for this phase).

Made with [Cursor](https://cursor.com)