### PR TITLE
chore: enrol Tier 2 Spec Kit + checkpoints

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,46 @@
+name: Feature / story
+description: Spec-traceable work for Tier 2 coding agents
+title: "feature: "
+labels: ["enhancement", "ready-for-agent"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Who is stuck and what hurts?
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Outcome
+      description: Measurable user/business result
+    validations:
+      required: true
+  - type: input
+    id: spec_ref
+    attributes:
+      label: Spec reference
+      description: Path or section in spec/ (e.g. spec/features/apply.feature)
+      placeholder: spec/features/….feature
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Prefer Gherkin Given/When/Then
+      value: |
+        Given …
+        When …
+        Then …
+    validations:
+      required: true
+  - type: checkboxes
+    id: constraints
+    attributes:
+      label: Constraints acknowledged
+      options:
+        - label: WCAG 2.1 AA / B.C. Design System for UI
+        - label: No personal information without PIA
+        - label: OpenShift deploy target (or ADR exception)

--- a/.github/mcp/mcp.json.example
+++ b/.github/mcp/mcp.json.example
@@ -1,0 +1,20 @@
+{
+  "_comment": "Copy into your local coding agent's MCP settings. Replace ABSOLUTE paths.",
+  "mcpServers": {
+    "bc-design-system": {
+      "command": "node",
+      "args": ["/ABSOLUTE/PATH/to/ai-sdlc/bc-design-system-mcp/dist/index.js"]
+    },
+    "bcgov-sdlc": {
+      "command": "node",
+      "args": ["/ABSOLUTE/PATH/to/ai-sdlc/bcgov-agentic-glue/sdlc-mcp/dist/index.js"]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github_pat}"
+      }
+    }
+  }
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- What user-visible change does this PR make? -->
+
+## Spec traceability
+
+- Spec / feature: <!-- e.g. spec/features/….feature -->
+- Task: <!-- e.g. TASK-001 -->
+- Constitution articles: <!-- e.g. P1, P2 -->
+
+## Evidence
+
+- [ ] `docs/pr-evidence.md` updated (or N/A — docs-only)
+
+## Test plan
+
+- [ ] …

--- a/.github/tier1/ENROLLED.md
+++ b/.github/tier1/ENROLLED.md
@@ -1,7 +1,7 @@
 # Tier 1 enrolled
 
 Pack source: patterns/tier1
-Enrolled at: 2026-08-11T22:55:28Z
+Enrolled at: 2026-08-11T23:06:22Z
 gh-aw sources: false
 
 Next:

--- a/.github/tier2/AGENTIC.md
+++ b/.github/tier2/AGENTIC.md
@@ -1,0 +1,102 @@
+# Tier 2 — agent backends & coding agent
+
+## What Tier 2 adds beyond Tier 1
+
+| Capability | Mechanism |
+| --- | --- |
+| Spec as source of truth | `spec/` + constitution in git |
+| Checkpoint gate | Actions workflow fails PRs missing artifacts |
+| Spec-aware review | Actions heuristic (+ optional LLM) and/or `gh-aw` |
+| Implementation | Label `ready-for-agent` → **auto-assign Copilot coding agent** |
+
+## Coding agent workflow
+
+### A. Local coding agent (recommended for day-to-day)
+
+See **[LOCAL.md](LOCAL.md)** — open the enrolled repo, wire MCP from `.github/mcp/mcp.json.example`, follow `AGENTS.md`, implement, push a draft PR.
+
+### B. Copilot cloud (GitHub)
+
+1. Issue uses the Feature template (spec ref + acceptance).
+2. Human adds label **`ready-for-agent`** (or Feature template includes it).
+3. Workflow **Tier 2 / Assign coding agent** assigns `copilot-swe-agent[bot]` via the Issues API (`agent_assignment`).
+4. Copilot opens a **draft PR**; checkpoint gate + spec review run.
+5. Human merges (checkpoint 3).
+
+Tier 1 triage only labels issues — it does **not** implement.
+
+### Secret (required for auto-assign)
+
+Actions `GITHUB_TOKEN` **cannot** assign Copilot (billing is tied to a user). Set:
+
+```bash
+# Fine-grained PAT: Issues RW, Contents RW, Pull requests RW, Metadata R
+# Classic: repo scope
+gh secret set COPILOT_ASSIGN_TOKEN --repo OWNER/REPO
+```
+
+Optional fallback: `COPILOT_GITHUB_TOKEN` (same user-token rules).
+
+Also required: **Copilot coding agent enabled** for the repo and token owner  
+(Settings → Copilot → Coding agent / org policy). If GraphQL `suggestedActors` does not list `copilot-swe-agent`, assignment will fail until that is turned on.
+
+### Config (`tier2.config.json`)
+
+```json
+"coding_agent": {
+  "auto_assign": true,
+  "assign_label": "ready-for-agent",
+  "base_branch": "main",
+  "custom_instructions": ""
+}
+```
+
+Set `auto_assign: false` to keep the label as a human-only signal.
+
+## Azure OpenAI (Actions LLM path)
+
+Same secrets as Tier 1. Use when `spec_review.mode` / `agent.mode` is `auto` or `llm` (not `gh-aw`).
+
+```bash
+REPO=bcgov/tier2-pattern-test   # or kmandryk/tier2-pattern-test
+
+# APIM subscription key (or native Azure key)
+gh secret set TIER1_LLM_API_KEY --repo "$REPO"
+
+# Full deployment URL (endpoint + /openai/deployments/{name})
+gh secret set TIER1_LLM_BASE_URL --repo "$REPO" \
+  --body "https://ai-services-hub-test-apim.azure-api.net/sdpr-invoice-automation/openai/deployments/gpt-5.1-chat"
+
+gh variable set TIER1_LLM_API_STYLE --repo "$REPO" --body "azure-apim"
+gh variable set TIER1_LLM_API_VERSION --repo "$REPO" --body "2025-04-01-preview"
+```
+
+In `tier2.config.json` (and `tier1.config.json` if enrolled):
+
+```json
+"agent": {
+  "mode": "auto",
+  "llm": {
+    "api_style": "azure-apim",
+    "base_url": "https://ai-services-hub-test-apim.azure-api.net/sdpr-invoice-automation/openai/deployments/gpt-5.1-chat",
+    "api_version": "2025-04-01-preview",
+    "api_key_env": "TIER1_LLM_API_KEY"
+  }
+},
+"spec_review": { "mode": "auto" }
+```
+
+If `spec_review.mode` is `gh-aw`, Azure/APIM is unused for review (Copilot CLI runs instead).
+
+## MCP
+
+See `.github/mcp/mcp.json.example`. Required for UI work: Design System MCP. Recommended: `bcgov-sdlc`, GitHub; Figma when design-in-the-loop.
+
+## gh-aw
+
+```bash
+# After enrol --with-gh-aw
+gh aw compile   # produces tier2-spec-review.lock.yml
+```
+
+Set `spec_review.mode` / reuse Tier 1 `agent.mode` carefully — avoid double comments from Actions + gh-aw on the same PR (prefer one).

--- a/.github/tier2/ENROL.md
+++ b/.github/tier2/ENROL.md
@@ -1,0 +1,95 @@
+# Enrol Tier 2 (external teams)
+
+**Goal:** Spec Kit + constitution + checkpoint gate + spec-aware review in *your* service repo. Prefer enrolling **with Tier 1** so triage / docs drift / CI diagnose stay available.
+
+## Prerequisites
+
+See **[YOU-PROVIDE.md](YOU-PROVIDE.md)**.
+
+## Enrol
+
+```bash
+chmod +x patterns/tier2/enrol.sh
+# Recommended: Tier 1 + Tier 2 + optional gh-aw sources
+./patterns/tier2/enrol.sh /path/to/your-service --with-tier1 --with-gh-aw
+
+cd /path/to/your-service
+${EDITOR:-nano} tier2.config.json   # project name
+${EDITOR:-nano} tier1.config.json   # if --with-tier1
+${EDITOR:-nano} constitution.md     # fill {{PLACEHOLDER}}s (or .specify/memory/constitution.md)
+
+git add .
+git commit -m "chore: enrol Tier 2 (Spec Kit + checkpoints)"
+git push -u origin HEAD
+```
+
+Scaffold already enrolled:
+
+```bash
+cp -R patterns/tier2-example /path/to/tier2-test
+cd /path/to/tier2-test
+# safe to re-run:
+../tier2/enrol.sh . --with-tier1
+```
+
+## After push
+
+1. **Actions** — Read and write workflow permissions (same as Tier 1).
+2. Run **Tier 2 / Preflight** (workflow_dispatch). Must be green.
+3. Connect MCP for a local coding agent (see **[LOCAL.md](LOCAL.md)** — start from `.github/mcp/mcp.json.example`).
+4. Open a **constitution PR** for architecture review; fill placeholders before production.
+5. Write technology-free `spec/spec.md` + `spec/features/*.feature` → **checkpoint 1**.
+6. Write `spec/plan.md` → **checkpoint 2**.
+7. Set secret **`COPILOT_ASSIGN_TOKEN`** (user PAT — see [AGENTIC.md](AGENTIC.md)). Ensure Copilot coding agent is enabled on the repo.
+8. Label issues `ready-for-agent` → workflow auto-assigns Copilot (or implement in IDE).
+9. Draft PRs get checkpoint-gate + spec-review; **human merges** (checkpoint 3).
+
+## Config
+
+`tier2.config.json` (see `tier2.config.example.json`):
+
+| Key | Purpose |
+| --- | --- |
+| `checkpoints.*` | What the gate requires |
+| `spec_review.mode` | `heuristic` / `auto` / `llm` / `gh-aw` |
+| `coding_agent.auto_assign` | Label → assign Copilot (`true` by default) |
+| `coding_agent.assign_label` | Default `ready-for-agent` |
+| `include_tier1` | Document intent; enrol with `--with-tier1` |
+
+### Agent backends
+
+See **[AGENTIC.md](AGENTIC.md)**.
+
+| Mode | Enrol | Secrets |
+| --- | --- | --- |
+| Heuristic / `auto` without key | default | none |
+| `auto` / `llm` | optional | `TIER1_LLM_API_KEY` (same as Tier 1) |
+| `gh-aw` | `--with-gh-aw` + `gh aw compile` | Copilot org billing or `COPILOT_GITHUB_TOKEN` |
+
+When `spec_review.mode` (or `agent.mode`) is `gh-aw`, the plain Actions **Spec review** job no-ops so you do not double-comment.
+
+```bash
+./enrol.sh /path/to/repo --with-tier1 --with-gh-aw
+cd /path/to/repo
+# set "spec_review": { "mode": "gh-aw" }  (and Tier 1 agent.mode if desired)
+gh extension install github/gh-aw
+gh aw compile
+git add .github/workflows/tier2-*.md .github/workflows/tier2-*.lock.yml tier2.config.json
+git commit -m "chore(tier2): gh-aw spec review" && git push
+```
+
+## What “done” looks like for a story
+
+1. Spec + feature signed (checkpoint 1)  
+2. Plan approved (checkpoint 2)  
+3. Coding agent (or human) opens draft PR  
+4. Checkpoint gate + spec review green/commented  
+5. Human merges (checkpoint 3)
+
+## Day-to-day
+
+After enrol, use **[OPERATE.md](OPERATE.md)** — checkpoints, local vs cloud implement, weekly rhythm, troubleshooting. Local agents: **[LOCAL.md](LOCAL.md)**.
+
+## Support
+
+Paste preflight / gate logs into an issue on the pattern repo. Do not disable the checkpoint gate to greenwash merges.

--- a/.github/tier2/ENROLLED.md
+++ b/.github/tier2/ENROLLED.md
@@ -1,0 +1,16 @@
+# Tier 2 enrolled
+
+Enrolled at: 2026-08-11T23:06:22Z
+tier1: true
+gh-aw: false
+
+Next:
+1. Fill constitution placeholders and open a constitution PR (architecture review).
+2. Edit tier2.config.json project name.
+3. Connect MCP servers (see .github/mcp/mcp.json.example).
+4. Write technology-free spec/spec.md + features; checkpoint 1.
+5. Write plan.md; checkpoint 2.
+6. Set secret COPILOT_ASSIGN_TOKEN (user PAT); enable Copilot coding agent on the repo.
+7. Label issues `ready-for-agent` → auto-assigns Copilot (or implement in IDE).
+8. PRs get checkpoint-gate + spec-review; human merges (checkpoint 3).
+9. Day-to-day ops: `.github/tier2/OPERATE.md` (local agents: LOCAL.md).

--- a/.github/tier2/LOCAL.md
+++ b/.github/tier2/LOCAL.md
@@ -1,0 +1,107 @@
+# Local agent — Tier 2
+
+GitHub Actions / cloud coding agents are optional. The same enrolled repo is meant to be driven from a **local coding agent** (IDE or CLI) against `AGENTS.md` + MCP + `spec/`.
+
+## Mental model
+
+| Path | Who implements |
+| --- | --- |
+| Label `ready-for-agent` | Cloud coding agent (e.g. Copilot) → draft PR |
+| **Local agent** | You + local coding agent in a clone → you open the PR |
+
+Both must respect constitution, `spec/`, and human merge (checkpoint 3). Local work does **not** need `COPILOT_ASSIGN_TOKEN`.
+
+## 1. Open the enrolled repo as the workspace
+
+```bash
+gh repo clone OWNER/your-service
+cd your-service
+# Open this folder as the workspace root for your coding agent
+```
+
+Root **`AGENTS.md`** is the instruction entryfile for agents working in the repo.
+
+## 2. Wire MCP (Design System + SDLC)
+
+Pack ships `.github/mcp/mcp.json.example`. Point your agent’s MCP configuration at those servers (tool-specific location varies — project or user MCP settings).
+
+```bash
+# Example: copy into a project MCP config your agent reads
+cp .github/mcp/mcp.json.example ./mcp.json   # or your tool’s project path
+# Edit absolute paths to your ai-sdlc clone
+```
+
+Example MCP server entries:
+
+```json
+{
+  "mcpServers": {
+    "bc-design-system": {
+      "command": "node",
+      "args": ["/ABSOLUTE/PATH/to/ai-sdlc/bc-design-system-mcp/dist/index.js"]
+    },
+    "bcgov-sdlc": {
+      "command": "node",
+      "args": ["/ABSOLUTE/PATH/to/ai-sdlc/bcgov-agentic-glue/sdlc-mcp/dist/index.js"]
+    }
+  }
+}
+```
+
+Build MCPs once if needed:
+
+```bash
+cd /path/to/ai-sdlc/bc-design-system-mcp && npm ci && npm run build
+cd /path/to/ai-sdlc/bcgov-agentic-glue/sdlc-mcp && npm ci && npm run build
+```
+
+Reload MCP in your agent. Confirm tools like `get_component`, `get_guidelines`, and constitution lint are available.
+
+**Optional:** GitHub MCP with a PAT for issue/PR context from the agent session.
+
+## 3. Optional project agent rules
+
+Add a short always-on rule / skill in whatever format your agent supports, for example:
+
+```markdown
+Follow AGENTS.md. Implement only from signed spec/features and tasks.
+Query bc-design-system MCP before UI. Do not merge; open a draft PR.
+Update docs/pr-evidence.md on implementation changes.
+```
+
+## 4. Typical local task loop
+
+1. **Pick work** — GitHub issue or a row in `spec/tasks.md` with a feature file reference.
+2. **Confirm checkpoints** — Spec/plan signed enough for the slice (or you’re only editing `spec/` for checkpoint 1).
+3. **Prompt the agent**, e.g.:
+
+   > Implement issue #N / TASK-00X per `spec/features/….feature`.
+   > Follow AGENTS.md and constitution. Query Design System MCP for any UI.
+   > Open a draft PR; update `docs/pr-evidence.md`. Do not merge.
+
+4. **Review locally** — run app/tests; skim diff vs acceptance criteria.
+5. **Push branch + draft PR** — Tier 2 checkpoint gate + spec review run on GitHub.
+6. **Human merges** (checkpoint 3).
+
+## 5. Models: local agent vs Actions
+
+Your local agent’s model selection is separate from repo `TIER1_LLM_*` secrets (those are for **GitHub Actions** scripts only).
+
+- Local sessions: use whatever models your org allows in the agent product.
+- Actions triage/spec-review LLM: keep `TIER1_LLM_*` on the repo (APIM may require private network — see wiki `synthesis/bcgov-pattern-packs`).
+
+## 6. Pattern repo vs service repo
+
+| Workspace | Use |
+| --- | --- |
+| `ai-sdlc` | Improve packs, wiki, MCP servers |
+| Enrolled service | Implement product work under Spec Kit |
+
+Open the **service** as the workspace when completing feature tasks.
+
+## Quick verify
+
+- [ ] `AGENTS.md` has Tier 2 section  
+- [ ] MCP servers connected in the local agent  
+- [ ] Agent can call `get_component` / SDLC lint  
+- [ ] Agent change lands in a **draft** PR; Actions gate runs  

--- a/.github/tier2/OPERATE.md
+++ b/.github/tier2/OPERATE.md
@@ -1,0 +1,187 @@
+# Operate Tier 2
+
+Human playbook for **day-to-day use** of the Tier 2 pattern after enrol.  
+For first-time setup see [ENROL.md](ENROL.md). Backends & coding agent: [AGENTIC.md](AGENTIC.md). Local IDE agents: [LOCAL.md](LOCAL.md).
+
+**What Tier 2 is:** spec-driven delivery — constitution + Spec Kit in git, human checkpoints, PR gates, optional Copilot assign, optional MCP for local agents.  
+**What it is not:** a replacement for Tier 1 intake automation. Prefer running **with Tier 1** (`enrol --with-tier1`).
+
+---
+
+## Who does what
+
+| Role | Responsibilities |
+| --- | --- |
+| **Product / tech lead** | Owns constitution placeholders → real standards; signs checkpoint 1–2; merges (checkpoint 3) |
+| **Developers** | Write `spec/` and features; implement from signed work; draft PRs only until gate is green |
+| **Local coding agent users** | Follow `AGENTS.md` + MCP; never self-merge |
+| **Repo maintainers** | `tier2.config.json`, secrets (`COPILOT_ASSIGN_TOKEN`, LLM), branch protection, MCP paths |
+| **Platform** | Pack updates, org Copilot coding-agent policy, APIM/runner access for Actions LLM |
+
+---
+
+## The story of a change
+
+```text
+Constitution (living standards)
+        ↓
+Spec + features  ──►  Checkpoint 1 (human: did we agree what to build?)
+        ↓
+Plan             ──►  Checkpoint 2 (human: is the plan sound?)
+        ↓
+Implement (local agent or Copilot cloud) ──► draft PR
+        ↓
+Checkpoint gate + spec review (CI)
+        ↓
+Human merge      ──►  Checkpoint 3 (does the PR match what we said?)
+```
+
+Agents may draft; **humans** accept intent, plan, and ship.
+
+---
+
+## Artifacts you keep current
+
+| Path | Role |
+| --- | --- |
+| `constitution.md` (and/or `.specify/memory/constitution.md`) | Non-negotiables: security, a11y, logging, stack |
+| `spec/spec.md` | Technology-light “what” |
+| `spec/features/*.feature` | Acceptance scenarios |
+| `spec/plan.md` | Approach for the slice |
+| `spec/tasks.md` | Implementable breakdown |
+| `docs/pr-evidence.md` | Evidence pack for reviews (when required) |
+| `AGENTS.md` | Entryfile for coding agents |
+| `tier2.config.json` | Gates, review mode, coding-agent assign |
+
+Fill `{{PLACEHOLDER}}`s before treating the repo as production-ready.
+
+---
+
+## Human checkpoints (operate these deliberately)
+
+| # | When | Owner asks | Exit |
+| --- | --- | --- | --- |
+| **1 — Spec** | Before implementation of a slice | Is the behaviour clear and testable? | Spec + features agreed (PR or recorded review) |
+| **2 — Plan** | Before coding the slice | Is the approach safe and sized? | `spec/plan.md` agreed |
+| **3 — Ship** | Before merge to the default branch | Does this PR match spec/plan and clear gates? | Human merge only |
+
+Do not turn off the checkpoint gate to “make CI green.” Fix the artifacts or the PR scope.
+
+---
+
+## Two ways to implement
+
+### A. Local coding agent (default day-to-day)
+
+1. Clone the **service** repo (not the pattern monorepo) as the agent workspace.
+2. Wire MCP from `.github/mcp/mcp.json.example` — see [LOCAL.md](LOCAL.md).
+3. Prompt against a signed issue / `spec/tasks.md` row; require a **draft** PR.
+4. Let checkpoint gate + spec review run on GitHub; you merge.
+
+No `COPILOT_ASSIGN_TOKEN` required for this path.
+
+### B. Copilot cloud coding agent
+
+1. Issue uses the Feature template (spec ref + acceptance).
+2. Add label **`ready-for-agent`** (configurable).
+3. Workflow assigns Copilot → Copilot opens a **draft** PR.
+4. Gate + review run; **you** merge.
+
+Needs: coding agent enabled on the repo + secret **`COPILOT_ASSIGN_TOKEN`** (user PAT — `GITHUB_TOKEN` cannot assign). Details: [AGENTIC.md](AGENTIC.md).
+
+You can use A and B on different issues; both must respect the same checkpoints.
+
+---
+
+## What CI enforces
+
+| Workflow | Purpose |
+| --- | --- |
+| **Tier 2 / Preflight** | Manual sanity (scripts, config) |
+| **Checkpoint gate** | PR fails if required constitution/spec/plan/features are missing for the paths touched |
+| **Spec review** | Heuristic and/or LLM / gh-aw comment on implementation PRs |
+| **Assign coding agent** | Label → Copilot (if enabled) |
+
+If Tier 1 is enrolled, triage / docs drift / CI diagnose continue as in the [Tier 1 operate](../tier1/OPERATE.md) playbook — separate config file (`tier1.config.json`).
+
+---
+
+## Config you’ll actually touch
+
+Root file: **`tier2.config.json`**.
+
+| Knob | Typical use |
+| --- | --- |
+| `checkpoints.*` | What the gate requires; `impl_path_prefixes` must match your code layout |
+| `checkpoints.strict_placeholders` | Tighten when scaffolds are filled |
+| `spec_review.mode` | `heuristic` · `auto` · `llm` · `gh-aw` |
+| `spec_review.require_evidence` / `evidence_path` | Expect `docs/pr-evidence.md` updates |
+| `coding_agent.auto_assign` | `false` = label is human signal only |
+| `coding_agent.assign_label` | Default `ready-for-agent` |
+| `agent.llm.*` | Actions LLM for spec review (same secret family as Tier 1: `TIER1_LLM_*`) |
+
+`include_tier1: true` documents intent; enrol still needs `--with-tier1`.
+
+### Review backends — stay on one writer
+
+Same rule as Tier 1: don’t let Actions LLM **and** gh-aw both comment on every PR. Set `spec_review.mode` to match the backend you want. Tier 1’s `agent.mode` is independent — you may use gh-aw for triage and heuristic for spec review, or align them for simplicity.
+
+---
+
+## Normal weekly rhythm
+
+1. **Preflight** after pack or config changes (Tier 2 and Tier 1 if present).
+2. **Constitution PR** when standards change — treat it as architecture review, not a drive-by edit.
+3. **One vertical slice** at a time: spec → plan → implement → draft PR → merge.
+4. **Label hygiene** — only `ready-for-agent` when the slice is ready for a cloud agent (acceptance clear, checkpoints 1–2 done).
+5. **Read gate failures** — missing feature file or plan usually means the PR is ahead of the paper trail; fix artifacts, don’t bypass.
+6. **Evidence** — keep `docs/pr-evidence.md` honest when `require_evidence` is on.
+
+---
+
+## First-week checklist (after enrol)
+
+- [ ] Actions: workflow permissions **Read and write**
+- [ ] **Tier 2 / Preflight** green (and Tier 1 preflight if enrolled)
+- [ ] Replace constitution / spec placeholders for a thin pilot slice
+- [ ] Open a constitution or spec PR and practice checkpoint 1
+- [ ] Wire local MCP **or** set `COPILOT_ASSIGN_TOKEN` + confirm `copilot-swe-agent` is available
+- [ ] Land one **draft** implementation PR; confirm checkpoint gate + spec review run
+- [ ] Human merges (checkpoint 3) — confirm branch protection doesn’t allow bot self-merge
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | What to try |
+| --- | --- | --- |
+| Checkpoint gate fails on every PR | Placeholders / missing `spec/` files / wrong `impl_path_prefixes` | Fill scaffold; align prefixes with real paths; see gate logs |
+| Spec review silent | `spec_review.enabled: false` or mode/skip mismatch | Check config; ensure PR touches `spec_review.paths` |
+| Double review comments | Actions + gh-aw both writing | One `spec_review.mode` |
+| `ready-for-agent` no draft PR | Coding agent off, bad PAT, or assign workflow failed | `suggestedActors` / secret / workflow log — see AGENTIC.md |
+| Local agent ignores DS / constitution | MCP not wired or wrong absolute paths | [LOCAL.md](LOCAL.md); rebuild MCP `dist/` |
+| LLM review 403 | APIM private network vs GitHub-hosted runners | Use heuristic/gh-aw for review, or private runners — wiki pattern-packs status |
+| Tier 1 quiet after Tier 2 enrol | Forgot `--with-tier1` | Re-run enrol with the flag (keeps existing configs) |
+
+Org blockers (APIM, Copilot): pattern monorepo `wiki/synthesis/bcgov-pattern-packs.md`, or ask platform.
+
+---
+
+## Updating the pack
+
+```bash
+./patterns/tier2/enrol.sh /path/to/your-service --with-tier1 [--with-gh-aw]
+```
+
+Overwrites Tier 2 workflows/scripts; preserves existing `tier2.config.json`, `tier1.config.json`, and filled `spec/` / constitution when already present. Diff carefully. Re-compile gh-aw locks after editing `.md` sources.
+
+---
+
+## Related docs
+
+| Doc | Use when |
+| --- | --- |
+| [ENROL.md](ENROL.md) | First install |
+| [AGENTIC.md](AGENTIC.md) | Modes, Copilot assign, Azure/APIM, gh-aw |
+| [LOCAL.md](LOCAL.md) | IDE / local agent loop |
+| Tier 1 operate | Intake automation — `.github/tier1/OPERATE.md` if enrolled with Tier 1 |

--- a/.github/tier2/labels.yml
+++ b/.github/tier2/labels.yml
@@ -1,0 +1,13 @@
+# Apply with: gh label create / import
+- name: ready-for-agent
+  color: "0E6027"
+  description: Safe to assign coding agent
+- name: checkpoint-1-spec
+  color: "0052CC"
+  description: Spec sign-off checkpoint
+- name: checkpoint-2-plan
+  color: "0052CC"
+  description: Plan approval checkpoint
+- name: needs-spec-trace
+  color: "B60205"
+  description: PR missing spec/feature/task link

--- a/.github/tier2/packs/pr-evidence/EVIDENCE.md.template
+++ b/.github/tier2/packs/pr-evidence/EVIDENCE.md.template
@@ -1,0 +1,52 @@
+# PR evidence — {{TITLE}}
+
+| Field | Value |
+| --- | --- |
+| PR / branch | {{BRANCH}} |
+| Spec refs | {{SPEC_REFS}} |
+| Constitution articles touched | {{CONSTITUTION_REFS}} |
+| Tasks | {{TASK_REFS}} |
+| Authoring agent | {{AGENT}} |
+| Generated | {{GENERATED_AT}} |
+
+## Intent
+
+{{INTENT}}
+
+## Spec traceability
+
+| Scenario / requirement | Implemented? | Notes |
+| --- | --- | --- |
+{{SCENARIO_ROWS}}
+
+
+## Design system & accessibility
+
+| Check | Result |
+| --- | --- |
+| DS components used (list) | {{DS_COMPONENTS}} |
+| Tokens used (not hard-coded colour) | {{DS_TOKENS}} |
+| BC Sans imported | {{BC_SANS}} |
+| Manual a11y notes | {{A11Y_NOTES}} |
+
+## Public-service minimums
+
+Checklist IDs addressed this PR: {{MINIMUMS_IDS}}
+
+## Tests
+
+| Type | Command / path | Result |
+| --- | --- | --- |
+| Unit | {{UNIT}} | |
+| Acceptance / feature | {{ACCEPTANCE}} | |
+| A11y automation | {{A11Y_CI}} | |
+
+## Risks & follow-ups
+
+- {{RISKS}}
+
+## Human checkpoint 3
+
+Reviewer confirms: PR matches signed spec/plan; no constitution violations; ready to merge.
+
+- Reviewer: _______________ Date: _______________

--- a/.github/tier2/packs/pr-evidence/README.md
+++ b/.github/tier2/packs/pr-evidence/README.md
@@ -1,0 +1,18 @@
+# Agent PR evidence pack
+
+Compact report agents attach to draft PRs so humans can review against **spec + constitution**, not vibe.
+
+## Contents
+
+| File | Role |
+| --- | --- |
+| [`EVIDENCE.md.template`](EVIDENCE.md.template) | Markdown template for `docs/pr-evidence.md` or PR body |
+| [`generate.mjs`](generate.mjs) | Fills a skeleton from git + spec paths |
+
+## Generate
+
+```bash
+node packs/pr-evidence/generate.mjs --root /path/to/service --out docs/pr-evidence.md
+```
+
+Agents should update the Design System / test sections after implementation.

--- a/.github/tier2/packs/pr-evidence/generate.mjs
+++ b/.github/tier2/packs/pr-evidence/generate.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i === -1 ? fallback : process.argv[i + 1];
+}
+
+const root = path.resolve(arg("root", "."));
+const out = path.resolve(root, arg("out", "docs/pr-evidence.md"));
+const template = readFileSync(path.join(__dirname, "EVIDENCE.md.template"), "utf8");
+
+function listFeatures() {
+  const dir = path.join(root, "spec/features");
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter((f) => f.endsWith(".feature"));
+}
+
+const features = listFeatures();
+const scenarioRows =
+  features.length === 0
+    ? "| _(no feature files found)_ | | |"
+    : features.map((f) => `| \`${f}\` | TODO | |`).join("\n");
+
+const filled = template
+  .replaceAll("{{TITLE}}", arg("title", path.basename(root)))
+  .replaceAll("{{BRANCH}}", arg("branch", process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME || "local"))
+  .replaceAll("{{SPEC_REFS}}", features.length ? features.map((f) => `spec/features/${f}`).join(", ") : "spec/spec.md")
+  .replaceAll("{{CONSTITUTION_REFS}}", "P1–P8 (confirm)")
+  .replaceAll("{{TASK_REFS}}", "see spec/tasks.md")
+  .replaceAll("{{AGENT}}", arg("agent", "unspecified"))
+  .replaceAll("{{GENERATED_AT}}", new Date().toISOString())
+  .replaceAll("{{INTENT}}", "_Summarize user-visible change in 2–3 sentences._")
+  .replaceAll("{{SCENARIO_ROWS}}", scenarioRows)
+  .replaceAll("{{DS_COMPONENTS}}", "_e.g. Button, TextField, Header — from Design System MCP_")
+  .replaceAll("{{DS_TOKENS}}", "_list or 'via components'_")
+  .replaceAll("{{BC_SANS}}", "TODO")
+  .replaceAll("{{A11Y_NOTES}}", "TODO")
+  .replaceAll("{{MINIMUMS_IDS}}", "_e.g. A11Y-02, A11Y-04_")
+  .replaceAll("{{UNIT}}", "TODO")
+  .replaceAll("{{ACCEPTANCE}}", features.map((f) => `spec/features/${f}`).join(", ") || "TODO")
+  .replaceAll("{{A11Y_CI}}", "TODO")
+  .replaceAll("{{RISKS}}", "_None noted / …_");
+
+mkdirSync(path.dirname(out), { recursive: true });
+writeFileSync(out, filled);
+console.log(`Wrote ${out}`);

--- a/.github/tier2/packs/public-service-minimums/README.md
+++ b/.github/tier2/packs/public-service-minimums/README.md
@@ -1,0 +1,17 @@
+# Public-service minimums pack
+
+Controls that apply to **public-facing BC Gov services regardless of agentic tier** (including forever-Tier-0). Tooling stays voluntary; these outcomes do not.
+
+## Contents
+
+| File | Role |
+| --- | --- |
+| [`checklist.md`](checklist.md) | Human + CI checklist |
+| [`SKILL.md`](SKILL.md) | Agent skill — refuse / flag gaps |
+| [`ci-hints.yml`](ci-hints.yml) | Example job stubs to wire later |
+
+## Use
+
+- Attach `checklist.md` to the service repo under `docs/public-service-minimums.md`
+- Point agents at `SKILL.md` (agent skill / AGENTS.md link)
+- Map checklist IDs into checkpoint-gate or evidence pack

--- a/.github/tier2/packs/public-service-minimums/SKILL.md
+++ b/.github/tier2/packs/public-service-minimums/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: bcgov-public-service-minimums
+description: Enforce tier-independent minimums for public-facing BC Gov services (WCAG, privacy, security, OpenShift, accountability).
+---
+
+# Skill: public-service minimums
+
+When working on a **public-facing** BC Gov service (citizen or business users on the open internet), apply these rules even if the team is Tier 0 and has no Spec Kit.
+
+## Must
+
+1. Target **WCAG 2.1 AA**. Use B.C. Design System components; query the Design System MCP before UI work.
+2. Do not introduce personal information flows without an explicit **PIA** status in the repo (`spec/plan.md` or `docs/public-service-minimums.md`).
+3. Do not hard-code secrets. Do not log PI.
+4. Prefer **OpenShift** deploy conventions; if another target is used, require an ADR.
+5. Never self-merge. Leave evidence for human review.
+6. Fill or update the checklist IDs in `docs/public-service-minimums.md` (from this pack's `checklist.md`).
+
+## Refuse / escalate
+
+Stop and ask a human if asked to:
+
+- Ship UI that bypasses the design system "just this once" without an ADR
+- Send production-like personal data to a public model endpoint
+- Disable a11y or security CI to "get the demo green"
+- Merge without a named reviewer for citizen-impacting changes
+
+## Tools
+
+- Prefer `bcgov-sdlc` MCP: `check_public_minimums`, `lint_constitution`, `validate_gherkin`
+- Prefer `bc-design-system` MCP for components/tokens

--- a/.github/tier2/packs/public-service-minimums/checklist.md
+++ b/.github/tier2/packs/public-service-minimums/checklist.md
@@ -1,0 +1,54 @@
+# Public-facing service minimums (tier-independent)
+
+Service: {{SERVICE_NAME}}  
+Owner: {{ACCOUNTABLE_OFFICER}}  
+Last review: {{YYYY-MM-DD}}
+
+Mark each item `done` / `n/a` (with rationale) / `gap`.
+
+## Accessibility
+
+| ID | Requirement | Status | Evidence |
+| --- | --- | --- | --- |
+| A11Y-01 | WCAG 2.1 Level AA target documented | | |
+| A11Y-02 | UI uses B.C. Design System components (or approved exception ADR) | | |
+| A11Y-03 | Skip link to main content present | | |
+| A11Y-04 | All form controls have visible labels | | |
+| A11Y-05 | Icon-only controls have accessible names | | |
+| A11Y-06 | Status is not colour-only | | |
+| A11Y-07 | Automated a11y scan in CI (axe or equivalent) on critical journeys | | |
+
+## Privacy
+
+| ID | Requirement | Status | Evidence |
+| --- | --- | --- | --- |
+| PRIV-01 | Data classification recorded | | |
+| PRIV-02 | PIA completed before personal information in any env / model | | |
+| PRIV-03 | No PI in logs, analytics, or AI prompts by default | | |
+| PRIV-04 | Retention schedule identified | | |
+
+## Security
+
+| ID | Requirement | Status | Evidence |
+| --- | --- | --- | --- |
+| SEC-01 | AuthN/AuthZ approach documented | | |
+| SEC-02 | Secrets not in git; rotated via platform secret store | | |
+| SEC-03 | Dependency scanning enabled on default branch | | |
+| SEC-04 | Security review path known for classification | | |
+
+## Operability
+
+| ID | Requirement | Status | Evidence |
+| --- | --- | --- | --- |
+| OPS-01 | Deploy target is OpenShift PaaS (or ADR exception) | | |
+| OPS-02 | Health/readiness probes defined | | |
+| OPS-03 | Support / incident contact path documented | | |
+| OPS-04 | Decision/FOI trail reconstructable from git (spec + PR + evidence) | | |
+
+## Accountability
+
+| ID | Requirement | Status | Evidence |
+| --- | --- | --- | --- |
+| ACC-01 | Named accountable officer for production changes | | |
+| ACC-02 | Human merge required (no agent self-merge) | | |
+| ACC-03 | Acceptance criteria ownership assigned (CODEOWNERS or named QA) | | |

--- a/.github/tier2/packs/public-service-minimums/ci-hints.yml
+++ b/.github/tier2/packs/public-service-minimums/ci-hints.yml
@@ -1,0 +1,11 @@
+# Example job ideas — wire to your scanner images later.
+# Not a full workflow; copy fragments into service CI.
+
+# a11y:
+# - run: npx axe-cli http://localhost:3000 --exit
+
+# deps:
+# - uses: github/codeql-action or ministry standard dependency review
+
+# checkpoint:
+# - uses: ./.github/actions/checkpoint-gate

--- a/.github/tier2/scripts/assign-coding-agent.mjs
+++ b/.github/tier2/scripts/assign-coding-agent.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+/**
+ * Assign GitHub Copilot coding agent when an issue is labeled ready-for-agent.
+ *
+ * Requires a *user* token (PAT / OAuth / App user-to-server). GITHUB_TOKEN
+ * (Actions installation token) cannot assign Copilot — billing is tied to a user.
+ *
+ * Env:
+ *   ISSUE_NUMBER (required)
+ *   COPILOT_ASSIGN_TOKEN or COPILOT_GITHUB_TOKEN (user PAT)
+ *   GITHUB_TOKEN (for issue comments if assign token missing)
+ *   GITHUB_REPOSITORY (owner/repo) or --repo
+ */
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+function loadConfig(root) {
+  const p = path.join(root, "tier2.config.json");
+  if (!existsSync(p)) throw new Error("Missing tier2.config.json");
+  return JSON.parse(readFileSync(p, "utf8"));
+}
+
+function arg(name) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i === -1 ? undefined : process.argv[i + 1];
+}
+
+function ghJson(args, token, input) {
+  return execFileSync("gh", args, {
+    encoding: "utf8",
+    input,
+    env: { ...process.env, GH_TOKEN: token, GITHUB_TOKEN: token },
+  });
+}
+
+const root = process.env.GITHUB_WORKSPACE || process.cwd();
+const cfg = loadConfig(root);
+const ca = cfg.coding_agent || {};
+
+if (ca.enabled === false || ca.auto_assign === false) {
+  console.log("coding_agent.auto_assign disabled — skip");
+  process.exit(0);
+}
+
+const issue = arg("issue") || process.env.ISSUE_NUMBER;
+if (!issue) {
+  console.error("ISSUE_NUMBER or --issue required");
+  process.exit(1);
+}
+
+const repo =
+  arg("repo") ||
+  process.env.GITHUB_REPOSITORY ||
+  (() => {
+    try {
+      return execFileSync("gh", ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], {
+        encoding: "utf8",
+      }).trim();
+    } catch {
+      return null;
+    }
+  })();
+
+if (!repo || !repo.includes("/")) {
+  console.error("GITHUB_REPOSITORY or --repo owner/name required");
+  process.exit(1);
+}
+
+const userToken = process.env.COPILOT_ASSIGN_TOKEN || process.env.COPILOT_GITHUB_TOKEN || "";
+const commentToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || userToken;
+
+function postComment(body) {
+  if (!commentToken) return;
+  try {
+    ghJson(
+      [
+        "api",
+        "--method",
+        "POST",
+        "-H",
+        "Accept: application/vnd.github+json",
+        `repos/${repo}/issues/${issue}/comments`,
+        "--input",
+        "-",
+      ],
+      commentToken,
+      JSON.stringify({ body }),
+    );
+  } catch (e) {
+    console.warn("Could not comment:", e.message);
+  }
+}
+
+if (!userToken) {
+  const msg = [
+    "### Tier 2 — coding agent not assigned",
+    "",
+    "Label `ready-for-agent` was applied, but secret **`COPILOT_ASSIGN_TOKEN`** is not set.",
+    "",
+    "Copilot assignment requires a **user** PAT (Actions `GITHUB_TOKEN` cannot assign Copilot):",
+    "",
+    "- Fine-grained: Issues (RW), Contents (RW), Pull requests (RW), Metadata (R)",
+    "- Classic: `repo` scope",
+    "- Copilot coding agent must be enabled for this repository and the token owner",
+    "",
+    "After adding the secret, remove and re-apply `ready-for-agent`.",
+  ].join("\n");
+  console.error(msg);
+  postComment(msg);
+  process.exit(1);
+}
+
+const assignLabel = ca.assign_label || "ready-for-agent";
+const baseBranch = ca.base_branch || "main";
+const assignee = ca.assignee || "copilot-swe-agent[bot]";
+const customInstructions =
+  (ca.custom_instructions && String(ca.custom_instructions).trim()) ||
+  [
+    "Follow AGENTS.md and the repository constitution (constitution.md / .specify/memory/constitution.md).",
+    "Implement only what the issue acceptance criteria and linked spec/features require.",
+    "Open a draft pull request. Do not merge.",
+    "Update docs/pr-evidence.md when touching implementation paths.",
+    "Prefer B.C. Design System components for UI; meet WCAG 2.1 AA.",
+  ].join(" ");
+
+const issueMeta = JSON.parse(
+  ghJson(
+    ["api", `repos/${repo}/issues/${issue}`, "-H", "Accept: application/vnd.github+json"],
+    userToken,
+  ),
+);
+
+const labels = (issueMeta.labels || []).map((l) => l.name);
+if (!labels.includes(assignLabel)) {
+  console.log(`Issue #${issue} lacks label ${assignLabel} — skip`);
+  process.exit(0);
+}
+
+const already = (issueMeta.assignees || []).some((a) =>
+  ["copilot-swe-agent[bot]", "copilot-swe-agent", "Copilot"].includes(a.login),
+);
+if (already) {
+  console.log(`Issue #${issue} already assigned to Copilot — skip`);
+  process.exit(0);
+}
+
+const assignBody = {
+  assignees: [assignee],
+  agent_assignment: {
+    target_repo: repo,
+    base_branch: baseBranch,
+    custom_instructions: customInstructions,
+    custom_agent: ca.custom_agent || "",
+    model: ca.model || "",
+  },
+};
+
+console.log(`Assigning ${assignee} to ${repo}#${issue} (base=${baseBranch})…`);
+
+let res;
+try {
+  res = ghJson(
+    [
+      "api",
+      "--method",
+      "POST",
+      "-H",
+      "Accept: application/vnd.github+json",
+      "-H",
+      "X-GitHub-Api-Version: 2022-11-28",
+      `repos/${repo}/issues/${issue}/assignees`,
+      "--input",
+      "-",
+    ],
+    userToken,
+    JSON.stringify(assignBody),
+  );
+} catch (e) {
+  const err = e.stderr?.toString?.() || e.message;
+  console.error("Assign failed:", err);
+  postComment(
+    [
+      "### Tier 2 — coding agent assign failed",
+      "",
+      `Could not assign \`${assignee}\` automatically.`,
+      "",
+      "Common causes:",
+      "- Token is not a **user** PAT / OAuth token",
+      "- Copilot coding agent is not enabled for this repo + token owner",
+      "- PAT missing Issues / Contents / Pull requests write",
+      "",
+      `Error (truncated): \`${String(err).slice(0, 400).replace(/`/g, "'")}\``,
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+const assigned = JSON.parse(res);
+const logins = (assigned.assignees || []).map((a) => a.login).join(", ");
+console.log(`Assigned. Assignees now: ${logins || "(none returned)"}`);
+
+const comment = [
+  "### Tier 2 — coding agent assigned",
+  "",
+  `Assigned **${assignee}** because of label \`${assignLabel}\`.`,
+  "",
+  `- Base branch: \`${baseBranch}\``,
+  "- Expect a **draft PR** from Copilot; humans own merge (checkpoint 3).",
+  "- Checkpoint gate + spec review will run on that PR.",
+].join("\n");
+
+postComment(comment);
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, comment + "\n");
+}

--- a/.github/tier2/scripts/check-checkpoints.mjs
+++ b/.github/tier2/scripts/check-checkpoints.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * Plain Node checkpoint gate — no gh-aw.
+ * Usable via `node check-checkpoints.mjs` or as a local action entrypoint.
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+const args = process.argv.slice(2);
+function flag(name, fallback = undefined) {
+  const idx = args.indexOf(`--${name}`);
+  if (idx === -1) return fallback;
+  return args[idx + 1] ?? "true";
+}
+
+const root = path.resolve(flag("root", process.env.INPUT_ROOT || "."));
+const strictPlaceholders =
+  (flag("strict-placeholders", process.env.INPUT_STRICT_PLACEHOLDERS || "false") || "false") ===
+  "true";
+const requirePlanPrefixes = (
+  flag("require-plan-on-paths", process.env.INPUT_REQUIRE_PLAN_ON_PATHS || "src/,apps/,services/,packages/,deploy/") ||
+  ""
+)
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const results = [];
+
+function ok(id, message) {
+  results.push({ id, status: "pass", message });
+}
+function warn(id, message) {
+  results.push({ id, status: "warn", message });
+}
+function fail(id, message) {
+  results.push({ id, status: "fail", message });
+}
+
+function read(rel) {
+  const p = path.join(root, rel);
+  if (!existsSync(p)) return null;
+  return readFileSync(p, "utf8");
+}
+
+function findConstitution() {
+  const candidates = [
+    "constitution.md",
+    ".specify/memory/constitution.md",
+    "spec/constitution.md",
+  ];
+  for (const c of candidates) {
+    if (existsSync(path.join(root, c))) return c;
+  }
+  return null;
+}
+
+function listFeatures() {
+  const dir = path.join(root, "spec/features");
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter((f) => f.endsWith(".feature"));
+}
+
+function walkFiles(dir, acc = []) {
+  if (!existsSync(dir)) return acc;
+  for (const name of readdirSync(dir)) {
+    if (name === "node_modules" || name === ".git" || name === "dist") continue;
+    const p = path.join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) walkFiles(p, acc);
+    else acc.push(p);
+  }
+  return acc;
+}
+
+function changedPathsHint() {
+  // Optional: GITHUB_EVENT_PATH not required. Heuristic: if common impl dirs exist, require plan.
+  return requirePlanPrefixes.some((prefix) => existsSync(path.join(root, prefix.replace(/\/$/, ""))));
+}
+
+// --- checks ---
+
+const constitutionPath = findConstitution();
+if (!constitutionPath) {
+  fail("constitution_present", "No constitution.md found (tried root, .specify/memory/, spec/).");
+} else {
+  ok("constitution_present", `Found ${constitutionPath}`);
+  const body = read(constitutionPath) || "";
+  const required = ["P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8"];
+  const missing = required.filter((p) => !body.includes(`### ${p}`) && !body.includes(`## ${p}`));
+  if (missing.length) {
+    fail(
+      "constitution_platform_articles",
+      `Constitution missing platform article markers: ${missing.join(", ")} (expected ### P1 … ### P8)`,
+    );
+  } else {
+    ok("constitution_platform_articles", "Platform articles P1–P8 markers present");
+  }
+  if (/\{\{[A-Z0-9_]+\}\}/.test(body)) {
+    (strictPlaceholders ? fail : warn)(
+      "constitution_placeholders",
+      "Constitution still contains {{PLACEHOLDER}} tokens — fill before production use",
+    );
+  }
+}
+
+const spec = read("spec/spec.md");
+if (!spec) {
+  fail("spec_present", "spec/spec.md is missing");
+} else {
+  ok("spec_present", "spec/spec.md present");
+  for (const heading of ["## Problem", "## Outcome", "## Scope"]) {
+    if (!spec.includes(heading)) {
+      warn("spec_structure", `spec.md missing recommended heading: ${heading}`);
+    }
+  }
+  if (/\{\{[A-Z0-9_]+\}\}/.test(spec)) {
+    (strictPlaceholders ? fail : warn)(
+      "spec_placeholders",
+      "spec.md still contains {{PLACEHOLDER}} tokens",
+    );
+  }
+}
+
+const plan = read("spec/plan.md");
+const needsPlan = changedPathsHint();
+if (!plan) {
+  if (needsPlan) {
+    fail("plan_present", "spec/plan.md missing but implementation directories exist — required for checkpoint 2");
+  } else {
+    warn("plan_present", "spec/plan.md missing (ok only before architecture work starts)");
+  }
+} else {
+  ok("plan_present", "spec/plan.md present");
+}
+
+const features = listFeatures();
+if (features.length === 0) {
+  if (needsPlan) {
+    fail("features_present", "No spec/features/*.feature files — acceptance criteria required");
+  } else {
+    warn("features_present", "No feature files yet");
+  }
+} else {
+  ok("features_present", `${features.length} feature file(s): ${features.join(", ")}`);
+}
+
+// Report
+const failed = results.filter((r) => r.status === "fail");
+const warned = results.filter((r) => r.status === "warn");
+
+console.log(`Checkpoint gate — root=${root}\n`);
+for (const r of results) {
+  const mark = r.status === "pass" ? "PASS" : r.status === "warn" ? "WARN" : "FAIL";
+  console.log(`[${mark}] ${r.id}: ${r.message}`);
+}
+console.log(`\nSummary: ${results.length - failed.length - warned.length} pass, ${warned.length} warn, ${failed.length} fail`);
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  const lines = [
+    "### Checkpoint gate",
+    "",
+    "| Status | Check | Message |",
+    "| --- | --- | --- |",
+    ...results.map((r) => `| ${r.status} | ${r.id} | ${r.message.replace(/\|/g, "\\|")} |`),
+  ];
+  try {
+    const { appendFileSync } = await import("node:fs");
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join("\n") + "\n");
+  } catch {
+    /* ignore */
+  }
+}
+
+process.exit(failed.length ? 1 : 0);

--- a/.github/tier2/scripts/preflight.mjs
+++ b/.github/tier2/scripts/preflight.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/** Tier 2 preflight: config, spec scaffold, tier1 optional, workflows */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.env.GITHUB_WORKSPACE || process.cwd();
+const fail = [];
+const warn = [];
+const ok = (m) => console.log(`PASS  ${m}`);
+const bad = (m) => {
+  console.log(`FAIL  ${m}`);
+  fail.push(m);
+};
+const wrn = (m) => {
+  console.log(`WARN  ${m}`);
+  warn.push(m);
+};
+
+const cfgPath = path.join(root, "tier2.config.json");
+if (!existsSync(cfgPath)) bad("missing tier2.config.json");
+else {
+  ok("tier2.config.json");
+  const cfg = JSON.parse(readFileSync(cfgPath, "utf8"));
+  if (cfg.tier !== 2) wrn("tier field should be 2");
+}
+
+for (const f of [
+  "spec/spec.md",
+  "spec/plan.md",
+  "spec/tasks.md",
+  ".specify/memory/constitution.md",
+  "AGENTS.md",
+]) {
+  if (existsSync(path.join(root, f)) || (f.includes("constitution") && existsSync(path.join(root, "constitution.md"))))
+    ok(f.replace(".specify/memory/constitution.md", "constitution present"));
+  else bad(`missing ${f}`);
+}
+
+const features = path.join(root, "spec/features");
+if (existsSync(features)) ok("spec/features/");
+else bad("missing spec/features/");
+
+for (const w of [
+  "tier2-preflight.yml",
+  "tier2-checkpoint-gate.yml",
+  "tier2-spec-review.yml",
+  "tier2-assign-coding-agent.yml",
+]) {
+  if (existsSync(path.join(root, ".github/workflows", w))) ok(`workflow ${w}`);
+  else bad(`missing workflow ${w}`);
+}
+
+const cfgFull = existsSync(cfgPath) ? JSON.parse(readFileSync(cfgPath, "utf8")) : {};
+if (cfgFull.coding_agent?.auto_assign !== false) {
+  ok("coding_agent.auto_assign enabled (needs secret COPILOT_ASSIGN_TOKEN at runtime)");
+}
+
+if (existsSync(path.join(root, ".github/workflows", "tier2-spec-review.md"))) {
+  ok("gh-aw source tier2-spec-review.md");
+  if (existsSync(path.join(root, ".github/workflows", "tier2-spec-review.lock.yml")))
+    ok("gh-aw lock tier2-spec-review.lock.yml");
+  else wrn("gh-aw lock missing — run gh aw compile");
+}
+
+if (existsSync(path.join(root, "tier1.config.json"))) ok("tier1.config.json (Tier 1 included)");
+else wrn("tier1 not enrolled — run enrol with --with-tier1");
+
+if (existsSync(path.join(root, "docs/public-service-minimums.md"))) ok("public-service minimums doc");
+else wrn("copy packs/public-service-minimums/checklist.md → docs/public-service-minimums.md");
+
+console.log(`\nSummary: ${fail.length} fail, ${warn.length} warn`);
+process.exit(fail.length ? 1 : 0);

--- a/.github/tier2/scripts/spec-review.mjs
+++ b/.github/tier2/scripts/spec-review.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * Spec-aware PR review (heuristic + optional LLM).
+ * Checks that implementation PRs reference spec/features and evidence file.
+ * Env: PR_NUMBER or --pr N
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+function loadConfig(root) {
+  const p = path.join(root, "tier2.config.json");
+  if (!existsSync(p)) throw new Error("Missing tier2.config.json");
+  return JSON.parse(readFileSync(p, "utf8"));
+}
+
+function gh(args) {
+  return execFileSync("gh", args, { encoding: "utf8" }).trim();
+}
+
+function arg(name) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i === -1 ? undefined : process.argv[i + 1];
+}
+
+const root = process.env.GITHUB_WORKSPACE || process.cwd();
+const cfg = loadConfig(root);
+if (cfg.spec_review?.enabled === false) {
+  console.log("spec_review disabled");
+  process.exit(0);
+}
+
+const reviewMode = String(cfg.spec_review?.mode || cfg.agent?.mode || "heuristic").toLowerCase();
+if (reviewMode === "gh-aw" || reviewMode === "ghaw") {
+  console.log(
+    'Skipping Actions spec-review — mode is gh-aw. Use compiled tier2-spec-review.lock.yml',
+  );
+  process.exit(0);
+}
+
+const pr = arg("pr") || process.env.PR_NUMBER;
+if (!pr) {
+  console.error("PR_NUMBER or --pr required");
+  process.exit(1);
+}
+
+const prMeta = JSON.parse(
+  gh(["pr", "view", String(pr), "--json", "title,body,files,labels,author,baseRefName"]),
+);
+const files = (prMeta.files || []).map((f) => f.path);
+const implPrefixes = cfg.spec_review?.paths || cfg.checkpoints?.impl_path_prefixes || ["src/"];
+const touchesImpl = files.some((f) => implPrefixes.some((p) => f.startsWith(p)));
+const touchesSpec = files.some((f) => f.startsWith("spec/") || f.includes("constitution"));
+
+const findings = [];
+const body = `${prMeta.title || ""}\n${prMeta.body || ""}`;
+
+if (touchesImpl) {
+  if (!existsSync(path.join(root, "spec/spec.md"))) {
+    findings.push({ severity: "error", code: "no_spec", message: "Implementation PR but spec/spec.md missing" });
+  }
+  if (!/spec\/|features\/|#\d+|TASK-/i.test(body) && !touchesSpec) {
+    findings.push({
+      severity: "warning",
+      code: "no_spec_trace",
+      message: "PR body should link a spec section, feature file, or task id",
+    });
+  }
+  const evidencePath = cfg.spec_review?.evidence_path || "docs/pr-evidence.md";
+  const hasEvidenceInPr = files.includes(evidencePath);
+  const evidenceOnDisk = existsSync(path.join(root, evidencePath));
+  if (cfg.spec_review?.require_evidence && !hasEvidenceInPr && !evidenceOnDisk) {
+    findings.push({
+      severity: "warning",
+      code: "no_evidence",
+      message: `Missing ${evidencePath} — generate with packs/pr-evidence/generate.mjs`,
+    });
+  }
+  const featureDir = path.join(root, "spec/features");
+  if (existsSync(featureDir)) {
+    const features = execFileSync("ls", [featureDir], { encoding: "utf8" })
+      .split("\n")
+      .filter((f) => f.endsWith(".feature"));
+    if (features.length === 0) {
+      findings.push({ severity: "error", code: "no_features", message: "No spec/features/*.feature files" });
+    }
+  }
+}
+
+// Optional LLM narrative (OpenAI-compatible or Azure OpenAI — same secrets as Tier 1)
+let llmNote = "";
+const mode = (cfg.spec_review?.mode || cfg.agent?.mode || "heuristic").toLowerCase();
+const apiKey = process.env.TIER1_LLM_API_KEY || process.env.OPENAI_API_KEY;
+if ((mode === "llm" || mode === "auto") && apiKey && touchesImpl) {
+  try {
+    const llm = cfg.agent?.llm || {};
+    let base = (process.env.TIER1_LLM_BASE_URL || llm.base_url || "").replace(/\/$/, "");
+    const deployment =
+      process.env.TIER1_LLM_MODEL ||
+      process.env.AZURE_OPENAI_DEPLOYMENT ||
+      llm.model ||
+      "gpt-4o-mini";
+    if (!base && process.env.AZURE_OPENAI_ENDPOINT) {
+      const ep = process.env.AZURE_OPENAI_ENDPOINT.replace(/\/$/, "");
+      base = /\/openai\/deployments\//i.test(ep)
+        ? ep
+        : `${ep}/openai/deployments/${deployment}`;
+    }
+    if (!base) base = "https://api.openai.com/v1";
+    let apiStyle = (llm.api_style || process.env.TIER1_LLM_API_STYLE || "openai").toLowerCase();
+    if (apiStyle === "azure" && /azure-api\.net/i.test(base)) apiStyle = "azure-apim";
+    const isAzure = apiStyle === "azure" || apiStyle === "azure-apim";
+    const headers = { "Content-Type": "application/json" };
+    let url = `${base}/chat/completions`;
+    const body = {
+      messages: [
+        {
+          role: "system",
+          content:
+            "You review PRs against a BC Gov agentic SDLC. Comment briefly whether the change appears traced to spec/features and constitution constraints (WCAG, design system, PIA, OpenShift). Max 200 words.",
+        },
+        {
+          role: "user",
+          content: `PR title: ${prMeta.title}\nBody:\n${prMeta.body}\nFiles:\n${files.join("\n")}\nFindings so far: ${JSON.stringify(findings)}`,
+        },
+      ],
+    };
+    if (isAzure) {
+      const apiVersion =
+        llm.api_version ||
+        process.env.TIER1_LLM_API_VERSION ||
+        process.env.AZURE_OPENAI_API_VERSION ||
+        "2025-04-01-preview";
+      url = `${base}/chat/completions?api-version=${encodeURIComponent(apiVersion)}`;
+      if (apiStyle === "azure-apim") {
+        headers["Ocp-Apim-Subscription-Key"] = apiKey;
+        headers["api-key"] = apiKey;
+      } else {
+        headers["api-key"] = apiKey;
+      }
+    } else {
+      headers.Authorization = `Bearer ${apiKey}`;
+      body.model = deployment;
+      body.temperature = llm.temperature ?? 0.2;
+    }
+    const res = await fetch(url, { method: "POST", headers, body: JSON.stringify(body) });
+    if (res.ok) {
+      const data = await res.json();
+      llmNote = data.choices?.[0]?.message?.content || "";
+    } else {
+      console.warn(`LLM HTTP ${res.status}: ${(await res.text()).slice(0, 300)}`);
+    }
+  } catch (e) {
+    console.warn("LLM review skipped:", e.message);
+  }
+}
+
+const errors = findings.filter((f) => f.severity === "error");
+const warnings = findings.filter((f) => f.severity === "warning");
+const status = errors.length ? "FAIL" : warnings.length ? "WARN" : "PASS";
+
+const comment = [
+  `### Tier 2 spec review · \`${status}\``,
+  "",
+  `| | |`,
+  `| --- | --- |`,
+  `| Touches implementation | ${touchesImpl} |`,
+  `| Touches spec | ${touchesSpec} |`,
+  `| Findings | ${findings.length} |`,
+  "",
+  ...(findings.length
+    ? findings.map((f) => `- **${f.severity}** \`${f.code}\`: ${f.message}`)
+    : ["- No blocking findings from heuristic checks."]),
+  "",
+  llmNote ? `## Agent notes\n\n${llmNote}\n` : "",
+  "_Tier 2 pattern — human still owns checkpoint 3 (merge)._",
+].join("\n");
+
+console.log(comment);
+
+if (process.env.GITHUB_TOKEN || process.env.GH_TOKEN) {
+  try {
+    gh(["pr", "comment", String(pr), "--body", comment]);
+    console.log("Commented on PR", pr);
+  } catch (e) {
+    console.warn("Could not comment:", e.message);
+  }
+}
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  const { appendFileSync } = await import("node:fs");
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, comment + "\n");
+}
+
+process.exit(errors.length ? 1 : 0);

--- a/.github/workflows/tier2-assign-coding-agent.yml
+++ b/.github/workflows/tier2-assign-coding-agent.yml
@@ -1,0 +1,32 @@
+name: Tier 2 / Assign coding agent
+
+# On label ready-for-agent → assign copilot-swe-agent[bot] (draft PR).
+# Requires repo secret COPILOT_ASSIGN_TOKEN (user PAT). GITHUB_TOKEN cannot assign Copilot.
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign:
+    if: github.event.label.name == 'ready-for-agent'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Assign Copilot coding agent
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          COPILOT_ASSIGN_TOKEN: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_STEP_SUMMARY: ${{ github.step_summary }}
+        run: node .github/tier2/scripts/assign-coding-agent.mjs

--- a/.github/workflows/tier2-checkpoint-gate.yml
+++ b/.github/workflows/tier2-checkpoint-gate.yml
@@ -1,0 +1,39 @@
+name: Tier 2 / Checkpoint gate
+
+on:
+  pull_request:
+    paths:
+      - "spec/**"
+      - "constitution.md"
+      - ".specify/**"
+      - "src/**"
+      - "apps/**"
+      - "services/**"
+      - "server/**"
+      - "deploy/**"
+      - "AGENTS.md"
+      - "docs/**"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  checkpoints:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Run checkpoint gate
+        env:
+          GITHUB_STEP_SUMMARY: ${{ github.step_summary }}
+        run: |
+          ROOT="${{ github.workspace }}"
+          STRICT=$(jq -r '.checkpoints.strict_placeholders // false' tier2.config.json)
+          PREFIXES=$(jq -r '.checkpoints.impl_path_prefixes // ["src/"] | join(",")' tier2.config.json)
+          node .github/tier2/scripts/check-checkpoints.mjs \
+            --root "$ROOT" \
+            --strict-placeholders "$STRICT" \
+            --require-plan-on-paths "$PREFIXES"

--- a/.github/workflows/tier2-preflight.yml
+++ b/.github/workflows/tier2-preflight.yml
@@ -1,0 +1,30 @@
+name: Tier 2 / Preflight
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "tier2.config.json"
+      - "spec/**"
+      - ".specify/**"
+      - "constitution.md"
+      - "AGENTS.md"
+      - ".github/workflows/tier2-*.yml"
+      - ".github/tier2/**"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Tier 2 preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node .github/tier2/scripts/preflight.mjs

--- a/.github/workflows/tier2-spec-review.yml
+++ b/.github/workflows/tier2-spec-review.yml
@@ -1,0 +1,30 @@
+name: Tier 2 / Spec review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  spec-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Spec-aware review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TIER1_LLM_API_KEY: ${{ secrets.TIER1_LLM_API_KEY }}
+          TIER1_LLM_BASE_URL: ${{ secrets.TIER1_LLM_BASE_URL }}
+          TIER1_LLM_MODEL: ${{ vars.TIER1_LLM_MODEL }}
+          TIER1_LLM_API_STYLE: ${{ vars.TIER1_LLM_API_STYLE }}
+          TIER1_LLM_API_VERSION: ${{ vars.TIER1_LLM_API_VERSION }}
+          GITHUB_STEP_SUMMARY: ${{ github.step_summary }}
+        run: node .github/tier2/scripts/spec-review.mjs

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,0 +1,13 @@
+# Constitution pointer
+
+The canonical constitution for this bundle lives at:
+
+`bundles/greenfield/constitution.md`
+
+When copying the bundle into a service repo, place that file at:
+
+`.specify/memory/constitution.md`
+
+(or keep a root `constitution.md` and link it from here).
+
+Platform and project articles are defined in the full constitution file.

--- a/.specify/presets/compliance.md
+++ b/.specify/presets/compliance.md
@@ -1,0 +1,28 @@
+# Preset: BC Gov compliance (greenfield)
+
+Use with Spec Kit / agent prompts for public-sector delivery.
+
+## Constraints agents must not violate
+
+1. **WCAG 2.1 AA** on all user-facing surfaces.
+2. **B.C. Design System only** for UI primitives (`@bcgov/design-system-react-components`, tokens, BC Sans).
+3. **PIA before personal information** in any environment or model call.
+4. **OpenShift PaaS** as deploy target unless an ADR records an exception.
+5. **Spec in git** — no silent scope changes in chat-only agreements.
+6. **No self-merge** by agents; human checkpoint 3 remains.
+
+## Spec quality bar
+
+Reject or interrogate specs that:
+
+- Mix technology choices into `spec.md` (those belong in `plan.md`)
+- Use vague acceptance language ("fast", "user-friendly", "secure") without measurable criteria
+- Omit error, empty, and authorization paths for user journeys
+- Lack Gherkin (or equivalent) for citizen-facing flows
+
+## Suggested MCP set
+
+- `bc-design-system`
+- `bcgov-sdlc` (constitution lint, acceptance criteria, OpenShift, FOI packer)
+- Figma (when design is in scope)
+- GitHub

--- a/.specify/presets/greenfield.md
+++ b/.specify/presets/greenfield.md
@@ -1,0 +1,21 @@
+# Preset: greenfield delivery shape
+
+## Entry
+
+Empty `spec/` → constitution PR → intake → spec → design → plan → tasks → implement → review → deploy → operate.
+
+## Checkpoints
+
+| # | Question | Artifact |
+| --- | --- | --- |
+| 1 | Did we agree what to build? | `spec/spec.md` (+ features) merged |
+| 2 | Is the architecture sound? | `spec/plan.md` approved |
+| 3 | Does the PR do what we said? | Human merge of implementation PR |
+
+## Task slicing
+
+Prefer vertical slices that each deliver a testable scenario from `spec/features/`. Avoid "build all APIs then all UI" horizontal batches for the first milestone.
+
+## Constitution type
+
+**Aspirational** — how we intend to build. (Legacy projects use archaeological constitutions instead; not this bundle.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,28 @@ Backend is selected by `agent.mode` in `tier1.config.json`: `heuristic` | `auto`
 ## Upgrade path
 
 Tier 2 adds Spec Kit, constitution, Design System MCP, and human checkpoints. See the platform `bcgov-agentic-glue` bundles when you are ready.
+
+## Tier 2 — Spec-driven delivery
+
+This repository is enrolled in **Tier 2** of the BC Gov agentic SDLC pattern.
+
+### Before implementing
+
+1. Confirm work is in `spec/tasks.md` and traced to `spec/features/*.feature` (or an explicit spec section).
+2. Query **bc-design-system** MCP before UI (`get_component`, `get_guidelines`).
+3. Query **bcgov-sdlc** MCP for constitution / Gherkin / OpenShift checks when relevant.
+4. Do not invent scope outside the signed `spec/spec.md`.
+
+### Checkpoints (humans)
+
+1. Spec sign-off  
+2. Plan / architecture approval  
+3. Review & ship (no agent self-merge)
+
+### Evidence
+
+Update `docs/pr-evidence.md` on implementation PRs (`node .github/tier2/packs/pr-evidence/generate.mjs`).
+
+### Labels
+
+- `ready-for-agent` — triggers **Tier 2 / Assign coding agent** (Copilot draft PR), when `COPILOT_ASSIGN_TOKEN` is set

--- a/constitution.md
+++ b/constitution.md
@@ -1,0 +1,82 @@
+# Constitution — {{SERVICE_NAME}}
+
+> Aspirational constitution for a **greenfield** BC Gov digital service.
+> Replace `{{…}}` placeholders. Amend via pull request; do not silently override platform articles.
+
+**Ministry / program:** {{MINISTRY}}  
+**Service:** {{SERVICE_NAME}}  
+**Data classification:** {{internal | public | sensitive}}  
+**Deploy target:** OpenShift Private Cloud PaaS  
+**Last reviewed:** {{YYYY-MM-DD}}
+
+---
+
+## Platform articles (do not remove)
+
+### P1 — Accessibility
+
+All user-facing interfaces SHALL meet **WCAG 2.1 Level AA**. Accessibility is a legal duty for public-facing services, not a tier opt-in. Prefer B.C. Design System components that encode accessible behaviour (React Aria). Do not ship colour-only status, unlabeled icon buttons, or missing form labels.
+
+### P2 — Design system
+
+UI SHALL use `@bcgov/design-system-react-components` and `@bcgov/design-tokens`. Do not invent buttons, inputs, headers, or hard-coded brand colours. Agents MUST query the BC Design System MCP (or equivalent) before generating UI. Load BC Sans via `@bcgov/bc-sans`.
+
+### P3 — Privacy
+
+No personal information MAY enter a system, log, model prompt, or third-party AI API until a **Privacy Impact Assessment (PIA)** appropriate to the classification is complete and recorded. Prefer synthetic or anonymized fixtures in lower environments.
+
+### P4 — Deploy target
+
+Production and primary lower environments SHALL target **OpenShift** on the BC Gov Private Cloud PaaS unless an ADR explicitly documents an exception. Follow Private Cloud conventions (health probes, resource limits, no privileged containers by default).
+
+### P5 — Spec as source of truth
+
+Intent lives in versioned git under `spec/` (`spec.md`, `plan.md`, `tasks.md`, `features/*.feature`, this constitution). Chat is not the system of record. FOI-relevant decisions MUST be reconstructable from git artifacts.
+
+### P6 — Human checkpoints
+
+Humans own: (1) spec sign-off, (2) plan/architecture approval, (3) review & ship. Agents MUST NOT self-merge. Agent branches only; Actions on agent PRs require human approval where org policy requires it.
+
+### P7 — Test integrity
+
+Default: acceptance criteria owned under CODEOWNERS (or equivalent human review). The same agent session SHOULD NOT both author production code and solely author the only acceptance proof for high-risk behaviour without human QA sign-off.
+
+### P8 — Approved tools
+
+Agents MAY only use approved MCP servers and model routes for this classification. Sensitive workloads MUST NOT send source or data to public model endpoints outside policy.
+
+---
+
+## Project articles (customize)
+
+### J1 — Service purpose
+
+{{One paragraph: who the service is for and what outcome it delivers.}}
+
+### J2 — In scope / out of scope
+
+- **In:** {{…}}
+- **Out:** {{…}}
+
+### J3 — Forbidden patterns
+
+- {{e.g. direct JDBC from the UI tier; storing SIN; custom auth bypassing Entra}}
+
+### J4 — Domain language
+
+| Term | Meaning |
+| --- | --- |
+| {{Term}} | {{Definition}} |
+
+### J5 — Non-functional baselines
+
+- Availability / support hours: {{…}}
+- Performance: {{…}}
+- Retention: {{…}}
+
+---
+
+## Amendment
+
+Changes to platform articles require platform / architecture guild agreement.  
+Changes to project articles require the project's usual PR review (checkpoint 2 reviewers for material architecture impact).

--- a/docs/pilot-notes.md
+++ b/docs/pilot-notes.md
@@ -1,0 +1,18 @@
+# Agentic SDLC pilot notes (bcparks-ar-admin-agentic)
+
+## Scope for first Tier 2 story
+Prefer a **non-runtime** change that does not need Keycloak or `bcparks-ar-api`:
+
+- docs / AGENTS.md / constitution fill-in
+- lint or unit-test-only fixes
+- harness/config improvements
+
+## Proven Tier 1 (2026-08-11)
+- Preflight green
+- Issue triage on thin bug issue → `bug` + `needs-detail`
+- Demo fail CI → CI diagnose opened diagnosis issue
+
+## Next
+1. Fill `constitution.md` placeholders for this Angular admin UI
+2. Write a tiny `spec/spec.md` + feature for the first story
+3. Checkpoint gate on an implementation PR

--- a/docs/public-service-minimums.md
+++ b/docs/public-service-minimums.md
@@ -1,0 +1,54 @@
+# Public-facing service minimums (tier-independent)
+
+Service: {{SERVICE_NAME}}  
+Owner: {{ACCOUNTABLE_OFFICER}}  
+Last review: {{YYYY-MM-DD}}
+
+Mark each item `done` / `n/a` (with rationale) / `gap`.
+
+## Accessibility
+
+| ID | Requirement | Status | Evidence |
+| --- | --- | --- | --- |
+| A11Y-01 | WCAG 2.1 Level AA target documented | | |
+| A11Y-02 | UI uses B.C. Design System components (or approved exception ADR) | | |
+| A11Y-03 | Skip link to main content present | | |
+| A11Y-04 | All form controls have visible labels | | |
+| A11Y-05 | Icon-only controls have accessible names | | |
+| A11Y-06 | Status is not colour-only | | |
+| A11Y-07 | Automated a11y scan in CI (axe or equivalent) on critical journeys | | |
+
+## Privacy
+
+| ID | Requirement | Status | Evidence |
+| --- | --- | --- | --- |
+| PRIV-01 | Data classification recorded | | |
+| PRIV-02 | PIA completed before personal information in any env / model | | |
+| PRIV-03 | No PI in logs, analytics, or AI prompts by default | | |
+| PRIV-04 | Retention schedule identified | | |
+
+## Security
+
+| ID | Requirement | Status | Evidence |
+| --- | --- | --- | --- |
+| SEC-01 | AuthN/AuthZ approach documented | | |
+| SEC-02 | Secrets not in git; rotated via platform secret store | | |
+| SEC-03 | Dependency scanning enabled on default branch | | |
+| SEC-04 | Security review path known for classification | | |
+
+## Operability
+
+| ID | Requirement | Status | Evidence |
+| --- | --- | --- | --- |
+| OPS-01 | Deploy target is OpenShift PaaS (or ADR exception) | | |
+| OPS-02 | Health/readiness probes defined | | |
+| OPS-03 | Support / incident contact path documented | | |
+| OPS-04 | Decision/FOI trail reconstructable from git (spec + PR + evidence) | | |
+
+## Accountability
+
+| ID | Requirement | Status | Evidence |
+| --- | --- | --- | --- |
+| ACC-01 | Named accountable officer for production changes | | |
+| ACC-02 | Human merge required (no agent self-merge) | | |
+| ACC-03 | Acceptance criteria ownership assigned (CODEOWNERS or named QA) | | |

--- a/spec/features/example-happy-path.feature
+++ b/spec/features/example-happy-path.feature
@@ -1,0 +1,19 @@
+Feature: Example happy path
+  As a {{persona}}
+  I want {{capability}}
+  So that {{outcome}}
+
+  # Replace this file with real scenarios. Keep language testable and unambiguous.
+  # Vague words to avoid: fast, easy, secure, user-friendly, appropriately, etc.
+
+  Scenario: Successful completion with valid input
+    Given I am a {{persona}} on the {{page/start}}
+    When I {{action}} with valid {{data}}
+    Then I see {{specific observable result}}
+    And {{system state that can be verified}}
+
+  Scenario: Validation prevents incomplete submission
+    Given I am on the {{form}}
+    When I submit without {{required field}}
+    Then I see an error associated with {{field}}
+    And I remain on the form with my other input preserved

--- a/spec/plan.md
+++ b/spec/plan.md
@@ -1,0 +1,44 @@
+# Plan — {{SERVICE_NAME}}
+
+> Architecture and delivery approach. Technology belongs here (not in `spec.md`).
+
+## Summary
+
+{{How we will realize the spec.}}
+
+## Architecture
+
+```text
+{{e.g. Browser → OpenShift Route → Service → API → DB}}
+```
+
+## Key decisions (ADRs may expand)
+
+| Decision | Choice | Rationale |
+| --- | --- | --- |
+| UI | B.C. Design System React | Constitution P2 |
+| Hosting | OpenShift PaaS | Constitution P4 |
+| Auth | {{Entra / …}} | {{…}} |
+
+## Security & privacy
+
+- Classification: {{…}}
+- PIA status: {{not started / in progress / complete — link}}
+- Secrets: {{…}}
+
+## Test approach
+
+- Default integrity tier: **CODEOWNERS on acceptance criteria**
+- Features under `spec/features/` owned by: {{QA lead / path}}
+
+## Rollout
+
+- Environments: {{dev / test / prod}}
+- Migration / cutover: {{n/a for greenfield}}
+
+## Approval (checkpoint 2)
+
+| Role | Name | Date |
+| --- | --- | --- |
+| Architect / tech lead | | |
+| Security (if required) | | |

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1,0 +1,50 @@
+# Spec — {{SERVICE_NAME}}
+
+> Technology-free. Describe *what* and *why*, not frameworks or cloud products.
+
+## Problem
+
+{{Who is stuck, and what pain do they have today?}}
+
+## Outcome
+
+{{Measurable outcome for the user / business.}}
+
+## Users & personas
+
+| Persona | Goal |
+| --- | --- |
+| {{…}} | {{…}} |
+
+## Scope
+
+### In scope (this release)
+
+- {{…}}
+
+### Out of scope
+
+- {{…}}
+
+## Journeys
+
+1. {{Happy path name}} — see `features/{{name}}.feature`
+2. {{…}}
+
+## Non-functional requirements
+
+- Accessibility: WCAG 2.1 AA
+- Privacy: {{classification + PIA status}}
+- Availability: {{…}}
+
+## Open questions
+
+- [ ] {{…}}
+
+## Sign-off (checkpoint 1)
+
+| Role | Name | Date |
+| --- | --- | --- |
+| Product / PM | | |
+| BA | | |
+| QA (acceptance ownership) | | |

--- a/spec/tasks.md
+++ b/spec/tasks.md
@@ -1,0 +1,12 @@
+# Tasks — {{SERVICE_NAME}}
+
+Derive from `spec.md` + `features/`. Prefer vertical slices.
+
+## Milestone 1
+
+- [ ] {{TASK-001}} — {{description}} — covers `features/{{…}}.feature` scenarios {{…}}
+- [ ] {{TASK-002}} — …
+
+## Backlog
+
+- [ ] …

--- a/tier2.config.json
+++ b/tier2.config.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "project": "bcparks-ar-admin-agentic",
+  "tier": 2,
+  "include_tier1": true,
+  "checkpoints": {
+    "require_constitution": true,
+    "require_spec": true,
+    "require_plan_on_impl_paths": true,
+    "require_features": true,
+    "strict_placeholders": false,
+    "impl_path_prefixes": [
+      "src/",
+      "apps/",
+      "services/",
+      "packages/",
+      "deploy/",
+      "server/"
+    ]
+  },
+  "spec_review": {
+    "enabled": true,
+    "mode": "heuristic",
+    "paths": [
+      "src/",
+      "apps/",
+      "services/",
+      "server/",
+      "deploy/"
+    ],
+    "require_evidence": true,
+    "evidence_path": "docs/pr-evidence.md"
+  },
+  "coding_agent": {
+    "provider": "copilot",
+    "enabled": true,
+    "auto_assign": true,
+    "assign_label": "ready-for-agent",
+    "assignee": "copilot-swe-agent[bot]",
+    "base_branch": "main",
+    "draft_prs_only": true,
+    "custom_instructions": "",
+    "custom_agent": "",
+    "model": "",
+    "token_secret": "COPILOT_ASSIGN_TOKEN"
+  },
+  "mcp": {
+    "required": [
+      "bc-design-system",
+      "bcgov-sdlc",
+      "github"
+    ],
+    "optional": [
+      "figma"
+    ]
+  },
+  "agent": {
+    "mode": "auto",
+    "llm": {
+      "api_style": "azure-apim",
+      "base_url": "https://ai-services-hub-test-apim.azure-api.net/sdpr-invoice-automation/openai/deployments/gpt-5.1-chat",
+      "api_version": "2025-04-01-preview",
+      "model": "gpt-5.1-chat",
+      "api_key_env": "TIER1_LLM_API_KEY"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Enrol Tier 2 (with Tier 1 retained): Spec Kit scaffold, constitution, checkpoint gate, heuristic spec review, `ready-for-agent` assign workflow
- `spec_review.mode: heuristic` (no LLM secrets required for this phase)
- Pilot notes in `docs/pilot-notes.md`

## Test plan
- [ ] Actions → **Tier 2 / Preflight** → green
- [ ] Merge after preflight
- [ ] Fill constitution placeholders (human)
- [ ] First thin story: update `spec/` → open impl PR → confirm checkpoint gate + spec review comments
- [ ] Optional later: set `COPILOT_ASSIGN_TOKEN` for coding-agent auto-assign

Tier 1 smoke already proven on `main` (triage + CI diagnose).

Made with [Cursor](https://cursor.com)