### PR TITLE
docs(spec): AUTH-001 PKCE — checkpoint 1 (issue #11)

### DIFF
--- a/spec/features/auth-001-pkce.feature
+++ b/spec/features/auth-001-pkce.feature
@@ -1,0 +1,19 @@
+Feature: PKCE on real Keycloak initialisation
+  As a security-conscious operator of the A&R Admin UI
+  I want browser login to use PKCE S256
+  So that a stolen authorization code cannot be exchanged for tokens by an attacker
+
+  # Finding: RA AUTH-001 · Issue: #11
+  # Checkpoint 1 — acceptance owned by human sign-off in spec/spec.md
+  # Verification: unit/service tests (no live Keycloak required in CI)
+
+  Scenario: Real Keycloak init enables PKCE S256
+    Given local mock auth is not active
+    And Keycloak is enabled for the application
+    When the Keycloak service initialises the adapter
+    Then the init options include PKCE method S256
+
+  Scenario: Local mock auth does not call Keycloak init with PKCE
+    Given local mock auth is active
+    When the auth service initialises
+    Then a fake local session is established without Keycloak adapter init

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1,70 +1,83 @@
 # Spec — BC Parks Attendance & Revenue (Admin)
 
 > Technology-free. Describe *what* and *why*, not frameworks or cloud products.
-> Living slice for the agentic pilot; expand as more rapid-assessment findings are taken up.
+> Living document: one **active** slice for checkpoint 1; completed slices summarised below.
 
-## Problem
+---
 
-Staff without elevated permissions can still open certain admin-only screens if they add query parameters to the URL. Route protection compares the full URL string, so a small URL change skips the permission check in the browser. Backend APIs remain the authoritative control, but the admin UI must not present privileged screens to users who should not see them.
+## Active slice — AUTH-001 (PKCE on login)
 
-## Outcome
+**Issue:** [#11](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/11)  
+**Finding:** RA AUTH-001  
+**Feature:** `features/auth-001-pkce.feature`
 
-Authenticated users without the required capability cannot activate admin-only routes, including when the URL includes query parameters or a fragment. Users with the capability still can. The behaviour is specified in `features/authz-001-admin-route-guard.feature` and verified with automated tests that do not require a live identity provider or API.
+### Problem
 
-## Users & personas
+Staff sign in through the government’s identity broker in the browser. The app starts that login flow without the modern proof-of-possession step (PKCE) that public browser apps are expected to use. Without it, a stolen one-time login code from the redirect could be turned into a session by someone else.
+
+### Outcome
+
+Real browser login uses PKCE (S256). Local mock auth used for stand-up without IdP roles is unchanged. Automated tests prove the real-auth path configures PKCE without needing a live identity provider in CI.
+
+### Users & personas
 
 | Persona | Goal |
 | --- | --- |
-| Park Operator (non-admin) | Enter attendance/revenue; must not reach lock / manage-subareas / export-admin surfaces they are not permitted to use |
-| BC Parks sysadmin | Use lock-records, manage-subareas, and related admin routes, including deep links with query params |
-| Security reviewer | Confirm client-side route checks are not trivially bypassed |
+| Park Operator / BC Parks staff | Sign in safely via IDIR / BCeID as today |
+| Security reviewer | Confirm public OIDC client follows PKCE expectation |
+| Local developer | Keep `?localMockAuth=1` working without Keycloak |
 
-## Scope
+### Scope
 
-### In scope (this release — issue #6 / AUTHZ-001)
+#### In scope (issue #11)
 
-- Close the admin-route guard bypass caused by comparing the full URL (including query/fragment) for:
-  - export-reports
-  - lock-records
-  - review-data
-  - manage-subareas
-- Unit-test coverage for denied and allowed cases with query strings present
+- Enable PKCE S256 on real Keycloak initialisation
+- Automated proof (unit/service test) that init options include PKCE S256 for the real-auth path
+- Confirm local mock auth still bypasses Keycloak init
 
-### Out of scope
+#### Out of scope
 
-- Server-side authorization in `bcparks-ar-api` (assumed present; not changed here)
-- Adding a logout flow (AUTH-003)
-- Header nav visibility for manage-subareas (AUTHZ-003)
-- Broader `isAllowed()` fall-through redesign beyond what is needed for path matching (AUTHZ-002) — may be a follow-up
-- CloudFront / TLS / CSP findings
+- Changing Keycloak realm/client settings in `loginproxy.gov.bc.ca` (except documenting if IdP must allow PKCE — expected for modern clients)
+- Logout flow (AUTH-003), token refresh UX (AUTH-004), host allowlist on bearer injection (AUTH-007)
+- AUTHZ / CloudFront / logging findings
 
-## Journeys
+### Journeys
 
-1. Non-admin blocked on admin route with query string — see `features/authz-001-admin-route-guard.feature`
-2. Admin allowed on admin route with query string — same feature
+1. Real auth init configures PKCE — see `features/auth-001-pkce.feature`
+2. Local mock auth does not require Keycloak PKCE init — same feature
 
-## Non-functional requirements
+### Non-functional requirements
 
-- Accessibility: WCAG 2.1 AA (no UI chrome change expected in this slice)
-- Privacy: Internal staff app; no new personal data collection
-- Availability: No hosting change
-- Testability: Fix verifiable via unit tests in CI (`test-ci`)
+- Accessibility: no UI change expected
+- Privacy: no new personal data collection
+- Testability: verifiable in CI without live IdP
 
-## Open questions
+### Open questions (for checkpoint 1 reviewers)
 
-- [x] Is backend enforcement assumed for privileged mutations? **Yes** — this slice only hardens the UI guard.
-- [ ] Should denied attempts be logged client-side (LOG-003)? Deferred to a follow-up issue.
+- [ ] Does the existing Keycloak client `attendance-and-revenue` already allow/require PKCE, or is any IdP-side change needed? (Likely none for keycloak-js S256; confirm with platform if login fails after the code change.)
 
-## Traceability
+### Traceability
 
 | Finding | Issue | Feature |
 | --- | --- | --- |
-| RA AUTHZ-001 | #6 | `features/authz-001-admin-route-guard.feature` |
+| RA AUTH-001 | #11 | `features/auth-001-pkce.feature` |
 
-## Sign-off (checkpoint 1)
+### Sign-off (checkpoint 1) — **human required**
 
 | Role | Name | Date |
 | --- | --- | --- |
-| Product / PM | Pilot — proceed for agentic demo | 2026-08-12 |
-| Tech lead | Pilot — proceed for agentic demo | 2026-08-12 |
-| QA (acceptance ownership) | Unit tests + feature scenarios | 2026-08-12 |
+| Product / PM | | |
+| Tech lead | | |
+| QA (acceptance ownership) | | |
+
+> Do not add `ready-for-agent` to #11 until this table is filled and this spec PR is merged.
+
+---
+
+## Completed slices
+
+### AUTHZ-001 — Admin route guard path matching
+
+- **Issue:** [#6](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/6) (shipped)
+- **Feature:** `features/authz-001-admin-route-guard.feature`
+- **Summary:** Admin-only route checks use the URL path only so query/hash cannot skip capability checks.


### PR DESCRIPTION
## Summary
- Opens the human-led walkthrough for **AUTH-001** ([issue #11](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/11)).
- Sets `spec/spec.md` active slice to PKCE on Keycloak init; archives AUTHZ-001 as completed.
- Adds `spec/features/auth-001-pkce.feature`.
- **Checkpoint 1 sign-off table is blank** — please review and approve before merge (or comment approval and we fill your name/date).

## Not in this PR
- `spec/plan.md` / `spec/tasks.md` (checkpoint 2)
- Implementation or `ready-for-agent`

## Test plan
- [ ] Read active AUTH-001 section — clear & testable?
- [ ] Open questions acceptable (IdP PKCE support)?
- [ ] Approve checkpoint 1 → merge this PR
- [ ] Then proceed to checkpoint 2 (plan/tasks)


Made with [Cursor](https://cursor.com)