### PR TITLE
docs(plan): AUTH-001 PKCE — checkpoint 2 (issue #11)

### DIFF
--- a/spec/plan.md
+++ b/spec/plan.md
@@ -1,53 +1,60 @@
-# Plan — AuthGuard path matching (AUTHZ-001)
+# Plan — PKCE on Keycloak init (AUTH-001)
 
-> Architecture and delivery approach for issue #6 / RA AUTHZ-001.
+> Architecture and delivery approach for issue [#11](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/11) / RA AUTH-001.  
+> Checkpoint 1 (spec) is merged. This document is **checkpoint 2**.
 
 ## Summary
 
-Harden `AuthGuard` so admin-route permission checks use the **path** portion of the requested URL (ignore query string and fragment). Extend existing Karma/Jasmine tests. No dependency or hosting changes. No Design System / OpenShift migration.
+For **real** Keycloak sessions, pass `pkceMethod: 'S256'` into `keycloak-js` `init(...)` instead of `init({})`. Leave **local mock auth** on the early-return path (no Keycloak adapter init). Prove via unit/service tests that the real-auth init options include PKCE S256. No hosting, Design System, or realm admin changes in this slice.
 
 ## Architecture
 
 ```text
-Browser → AuthGuard.canActivate(route, state)
-        → KeycloakService.isAllowed(capability)
-        → allow component | redirect to "/" or "/unauthorized" | login flow
-
-API authorization remains in bcparks-ar-api (out of scope).
+App bootstrap
+  → ConfigService (ENVIRONMENT, KEYCLOAK_*)
+  → KeycloakService.init()
+       ├─ if local mock auth → fake JWT session (unchanged)
+       └─ else if KEYCLOAK_ENABLED → keycloakAuth.init({ pkceMethod: 'S256' })
+            → OIDC authorize + token with PKCE
 ```
 
 ## Key decisions
 
 | Decision | Choice | Rationale |
 | --- | --- | --- |
-| Match strategy | Compare path only (strip `?` / `#` from `state.url`), or equivalent Router URL-tree path | Fixes exact-string bypass; minimal diff |
-| Scope of routes | Same four admin checks already in the guard | Matches finding; avoids unrelated AUTHZ-002 redesign |
-| UI stack | Existing Angular + Parks theme | Constitution J6 |
-| Hosting | Unchanged AWS | Constitution J6 |
-| Verification | Unit tests in `auth.guard.spec.ts` | Pilot preference: no Keycloak/API required |
+| PKCE method | `S256` only | OAuth 2.0 Security BCP; supported by keycloak-js v25 |
+| Where to set it | Options object on `init(...)` in `KeycloakService` | Matches finding location; minimal blast radius |
+| Local mock auth | Unchanged early return | Stand-up without IdP roles must keep working |
+| IdP / realm changes | None in-repo; document residual risk if login fails | Client already public OIDC; PKCE is usually client-side |
+| UI / hosting | No change | Constitution J6 |
+| Verification | Extend `keycloak.service.spec.ts` (or equivalent) | CI without live loginproxy |
 
 ## Security & privacy
 
 - Classification: Internal staff UI
-- PIA: No new data flows
+- PIA: No new data collection
 - Secrets: None
-- Residual risk: Client-side guards are bypassable by a determined user who calls the API directly — API must continue to enforce roles
+- Residual risk: If the Keycloak client were misconfigured to reject PKCE, real login could fail until platform adjusts the client — mitigate by smoke-testing IDIR against `dev.loginproxy` after merge (human), and by keeping mock auth for local UI work
 
 ## Test approach
 
-- Extend `src/app/guards/auth.guard.spec.ts`
-- Scenarios from `spec/features/authz-001-admin-route-guard.feature`
-- CI: existing **PR Checks** (`yarn lint` / `yarn test-ci`)
+- Cover `features/auth-001-pkce.feature` scenarios in unit tests:
+  - Real path: init called with options including PKCE S256 (spy/mock Keycloak constructor/adapter)
+  - Mock path: adapter `init` not used for PKCE when local mock auth is active
+- CI: `yarn lint` + `yarn test-ci` on the implementation PR
 - Update `docs/pr-evidence.md` on the implementation PR
 
 ## Rollout
 
-- Environments: ship with next admin UI deploy (no special cutover)
-- Migration: n/a
+- Ship with next admin UI deploy
+- No data migration
+- Optional human smoke: real IDIR login on a lower environment after deploy
 
-## Approval (checkpoint 2)
+## Approval (checkpoint 2) — **human required**
 
 | Role | Name | Date |
 | --- | --- | --- |
-| Architect / tech lead | Pilot — proceed for agentic demo | 2026-08-12 |
-| Security (if required) | Finding is High; fix is local path match — proceed | 2026-08-12 |
+| Architect / tech lead | | |
+| Security (if required) | | |
+
+> Do not add `ready-for-agent` to #11 until this table is filled and this plan PR is merged.

--- a/spec/tasks.md
+++ b/spec/tasks.md
@@ -1,16 +1,26 @@
-# Tasks — AuthGuard path matching (AUTHZ-001)
+# Tasks — PKCE on Keycloak init (AUTH-001)
 
-Derive from `spec.md` + `features/authz-001-admin-route-guard.feature`. Issue: #6.
+Derive from `spec/spec.md` + `features/auth-001-pkce.feature`. Issue: [#11](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/11).
 
-## Milestone 1 — Close query-string bypass
+## Milestone 1 — Enable PKCE (after checkpoint 2 approval)
 
-- [ ] **TASK-001** — Change `AuthGuard` admin-route checks to compare path without query/fragment (all four protected routes) — covers scenarios *Non-admin denied with query string* and *Admin allowed with query string*
-- [ ] **TASK-002** — Add/extend unit tests in `auth.guard.spec.ts` for denied + allowed cases with `?…` URLs (and at least one fragment or multi-param case)
+- [ ] **TASK-001** — Change real Keycloak `init({})` to include `pkceMethod: 'S256'` in `KeycloakService` — covers scenario *Real Keycloak init enables PKCE S256*
+- [ ] **TASK-002** — Add/extend unit tests proving init options include PKCE S256 on the real-auth path, and that local mock auth does not require Keycloak PKCE init — covers both feature scenarios
 - [ ] **TASK-003** — Run `yarn lint` and `yarn test-ci`; update `docs/pr-evidence.md` on the implementation PR
-- [ ] **TASK-004** — Open **draft** PR linking #6; do not self-merge
+- [ ] **TASK-004** — Open **draft** PR linking #11; do not self-merge
 
-## Backlog (follow-ups, not this PR)
+## After checkpoint 2 merge (human)
 
-- [ ] LOG-003 — Log authorization denials in the guard
-- [ ] AUTHZ-002 — Review `isAllowed()` fall-through for unlisted routes
-- [ ] AUTHZ-003 — Hide manage-subareas nav for non-admins
+- [ ] Add label `ready-for-agent` to #11 **or** implement locally from this task list
+- [ ] Approve waiting Actions on the draft PR; review; merge (checkpoint 3)
+
+## Completed (prior slice)
+
+- [x] AUTHZ-001 — AuthGuard path matching (#6) — shipped
+
+## Backlog (not this slice)
+
+- [ ] AUTH-003 — Logout
+- [ ] AUTH-004 — Token refresh failure UX
+- [ ] AUTH-007 — Bearer host allowlist
+- [ ] LOG-003 — Log authorization denials


### PR DESCRIPTION
## Summary
- Checkpoint **2** artifacts for [issue #11](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/11) (AUTH-001).
- Updates `spec/plan.md` and `spec/tasks.md`: enable `pkceMethod: 'S256'` on real Keycloak init; keep local mock auth; unit-test proof.
- **Approval table is blank** — please sign off checkpoint 2 before merge.

## Not in this PR
- Implementation / `src/` changes
- `ready-for-agent` on #11

## Test plan
- [ ] Plan matches signed spec (#12 / `auth-001-pkce.feature`)
- [ ] Risks (IdP PKCE) acceptable
- [ ] Approve checkpoint 2 → merge
- [ ] Then label #11 `ready-for-agent` (or implement locally)


Made with [Cursor](https://cursor.com)