### PR TITLE
docs(spec): LOG-003 auth denial logging (checkpoint 1)

### DIFF
--- a/spec/features/log-003-auth-denial-logging.feature
+++ b/spec/features/log-003-auth-denial-logging.feature
@@ -1,0 +1,22 @@
+Feature: Log authorization denials from AuthGuard
+  As a security-conscious operator of the A&R Admin UI
+  I want authorization failures to be logged at warn level
+  So that probing of protected routes leaves a client-side audit trail
+
+  # Finding: RA LOG-003 · Issue: #15
+  # Checkpoint 1 — acceptance owned by human sign-off in spec/spec.md
+  # Verification: unit tests on AuthGuard (LoggerService spy); no live IdP required
+
+  Scenario: Unauthorized user denial is logged
+    Given I am authenticated
+    And I am not authorized for the application
+    When AuthGuard denies access and redirects to "/unauthorized"
+    Then a warn-level log records the denial
+    And the log includes the requested path and a denial reason
+
+  Scenario: Admin-only route denial is logged
+    Given I am authenticated and authorized for the application
+    And I lack the admin capability for "lock-records"
+    When AuthGuard redirects me away from "/lock-records"
+    Then a warn-level log records the denial
+    And the log includes the requested path and a denial reason

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -5,62 +5,64 @@
 
 ---
 
-## Active slice — AUTH-001 (PKCE on login)
+## Active slice — LOG-003 (auth denial logging)
 
-**Issue:** [#11](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/11)  
-**Finding:** RA AUTH-001  
-**Feature:** `features/auth-001-pkce.feature`
+**Issue:** [#15](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/15)  
+**Finding:** RA LOG-003  
+**Feature:** `features/log-003-auth-denial-logging.feature`
 
 ### Problem
 
-Staff sign in through the government’s identity broker in the browser. The app starts that login flow without the modern proof-of-possession step (PKCE) that public browser apps are expected to use. Without it, a stolen one-time login code from the redirect could be turned into a session by someone else.
+When staff are signed in but lack the right capability for a page, the app quietly redirects them (to unauthorized or home). Those denials are not written to any log. Someone probing admin routes or hitting unauthorized after login leaves no client-side trail for operators to review.
 
 ### Outcome
 
-Real browser login uses PKCE (S256). Local mock auth used for stand-up without IdP roles is unchanged. Automated tests prove the real-auth path configures PKCE without needing a live identity provider in CI.
+Every authorization-failure redirect from the route guard records a warn-level log that includes the requested path and why access was denied, plus a stable identity hint when the session already has one (not the raw token). Staff experience (redirect destinations) stays the same. Automated tests prove the log calls without a live identity provider. Building a server-side audit API is not part of this slice.
 
 ### Users & personas
 
 | Persona | Goal |
 | --- | --- |
-| Park Operator / BC Parks staff | Sign in safely via IDIR / BCeID as today |
-| Security reviewer | Confirm public OIDC client follows PKCE expectation |
-| Local developer | Keep `?localMockAuth=1` working without Keycloak |
+| Park Operator / BC Parks staff | Same redirects as today when not allowed |
+| Security reviewer / ops | See warn logs when authorization is denied |
+| Local developer | Behaviour covered in unit tests; mock auth still works |
 
 ### Scope
 
-#### In scope (issue #11)
+#### In scope (issue #15)
 
-- Enable PKCE S256 on real Keycloak initialisation
-- Automated proof (unit/service test) that init options include PKCE S256 for the real-auth path
-- Confirm local mock auth still bypasses Keycloak init
+- Warn-level log on each AuthGuard authorization-failure redirect (not authorized; admin-only route denied)
+- Log content: requested path, denial reason, identity hint when available
+- Unit tests asserting the log is emitted for both scenarios
 
 #### Out of scope
 
-- Changing Keycloak realm/client settings in `loginproxy.gov.bc.ca` (except documenting if IdP must allow PKCE — expected for modern clients)
-- Logout flow (AUTH-003), token refresh UX (AUTH-004), host allowlist on bearer injection (AUTH-007)
-- AUTHZ / CloudFront / logging findings
+- Server-side / central audit sink (future finding or platform work)
+- Changing who is allowed on which routes (AUTHZ-002 and related)
+- Raising Keycloak lifecycle log levels (LOG-002), dumping or scrubbing config logs (LOG-001)
+- Logout (AUTH-003), PKCE (shipped), CloudFront headers
 
 ### Journeys
 
-1. Real auth init configures PKCE — see `features/auth-001-pkce.feature`
-2. Local mock auth does not require Keycloak PKCE init — same feature
+1. Unauthorized user denial is logged — see `features/log-003-auth-denial-logging.feature`
+2. Admin-only route denial is logged — same feature
 
 ### Non-functional requirements
 
 - Accessibility: no UI change expected
-- Privacy: no new personal data collection
+- Privacy: only identity hints already present in the session; no new PII collection; do not log full tokens or full config
 - Testability: verifiable in CI without live IdP
+- Residual: whether warn lines appear in a given environment still depends on configured log level (LOG-004 is separate)
 
 ### Open questions (for checkpoint 1 reviewers)
 
-- [ ] Does the existing Keycloak client `attendance-and-revenue` already allow/require PKCE, or is any IdP-side change needed? (Likely none for keycloak-js S256; confirm with platform if login fails after the code change.)
+- [ ] Is browser-console warn acceptable for this pilot slice, with server-side audit deferred explicitly?
 
 ### Traceability
 
 | Finding | Issue | Feature |
 | --- | --- | --- |
-| RA AUTH-001 | #11 | `features/auth-001-pkce.feature` |
+| RA LOG-003 | #15 | `features/log-003-auth-denial-logging.feature` |
 
 ### Sign-off (checkpoint 1) — **human required**
 
@@ -70,11 +72,17 @@ Real browser login uses PKCE (S256). Local mock auth used for stand-up without I
 | Tech lead | | |
 | QA (acceptance ownership) | | |
 
-> Do not add `ready-for-agent` to #11 until this table is filled and this spec PR is merged.
+> Do not add `ready-for-agent` to #15 until this table is filled and this spec PR is merged.
 
 ---
 
 ## Completed slices
+
+### AUTH-001 — PKCE on Keycloak init
+
+- **Issue:** [#11](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/11) (shipped)
+- **Feature:** `features/auth-001-pkce.feature`
+- **Summary:** Real Keycloak init uses PKCE S256; local mock auth unchanged.
 
 ### AUTHZ-001 — Admin route guard path matching
 


### PR DESCRIPTION
## Summary

- Active slice for [#15](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/15) / RA LOG-003
- Feature: `spec/features/log-003-auth-denial-logging.feature`
- Moves AUTH-001 to completed slices

## Checkpoint

Checkpoint **1** — human BA/PM review before plan.


Made with [Cursor](https://cursor.com)