### PR TITLE
docs(plan): LOG-003 auth denial logging (checkpoint 2)

### DIFF
--- a/spec/plan.md
+++ b/spec/plan.md
@@ -1,46 +1,47 @@
-# Plan — PKCE on Keycloak init (AUTH-001)
+# Plan — Auth denial logging (LOG-003)
 
-> Architecture and delivery approach for issue [#11](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/11) / RA AUTH-001.  
+> Architecture and delivery approach for issue [#15](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/15) / RA LOG-003.  
 > Checkpoint 1 (spec) is merged. This document is **checkpoint 2**.
 
 ## Summary
 
-For **real** Keycloak sessions, pass `pkceMethod: 'S256'` into `keycloak-js` `init(...)` instead of `init({})`. Leave **local mock auth** on the early-return path (no Keycloak adapter init). Prove via unit/service tests that the real-auth init options include PKCE S256. No hosting, Design System, or realm admin changes in this slice.
+Inject `LoggerService` into `AuthGuard` and emit `warn` **before** each authorization-failure redirect (`/unauthorized` or home `/` for admin-only routes). Log payload includes requested path, denial reason, and a stable identity hint when available. Prove via unit tests with a `LoggerService` spy. No server-side audit API, no route-policy changes, no UI.
 
 ## Architecture
 
 ```text
-App bootstrap
-  → ConfigService (ENVIRONMENT, KEYCLOAK_*)
-  → KeycloakService.init()
-       ├─ if local mock auth → fake JWT session (unchanged)
-       └─ else if KEYCLOAK_ENABLED → keycloakAuth.init({ pkceMethod: 'S256' })
-            → OIDC authorize + token with PKCE
+Router navigation
+  → AuthGuard.canActivate(route, state)
+       ├─ not authenticated → login / IdP (unchanged; not this slice)
+       ├─ not authorized → logger.warn(...) → /unauthorized
+       ├─ admin-only denied → logger.warn(...) → /
+       └─ allowed → true
 ```
 
 ## Key decisions
 
 | Decision | Choice | Rationale |
 | --- | --- | --- |
-| PKCE method | `S256` only | OAuth 2.0 Security BCP; supported by keycloak-js v25 |
-| Where to set it | Options object on `init(...)` in `KeycloakService` | Matches finding location; minimal blast radius |
-| Local mock auth | Unchanged early return | Stand-up without IdP roles must keep working |
-| IdP / realm changes | None in-repo; document residual risk if login fails | Client already public OIDC; PKCE is usually client-side |
-| UI / hosting | No change | Constitution J6 |
-| Verification | Extend `keycloak.service.spec.ts` (or equivalent) | CI without live loginproxy |
+| Where to log | `AuthGuard` at each authz-failure redirect | Matches finding location; minimal blast radius |
+| Log level | `LoggerService.warn` | Visible above typical info/debug; matches signed spec |
+| Identity hint | Prefer existing Keycloak helpers (e.g. username/preferred_username/sub if already exposed); never log raw JWT or full config | Privacy; constitution-friendly |
+| Path in log | Use same path-only form as AUTHZ-001 (`requestPath`) | Consistent with guard matching |
+| Server audit | Out of scope | Explicit CP1 acceptance for pilot |
+| Log-level residual | Environments with `LogLevel.Off` still won’t print (LOG-004) | Document; do not fix LOG-004 here |
+| Verification | Extend `auth.guard.spec.ts` | CI without live IdP |
 
 ## Security & privacy
 
 - Classification: Internal staff UI
-- PIA: No new data collection
+- PIA: No new data collection; only session-derived identity hints already available to the guard
 - Secrets: None
-- Residual risk: If the Keycloak client were misconfigured to reject PKCE, real login could fail until platform adjusts the client — mitigate by smoke-testing IDIR against `dev.loginproxy` after merge (human), and by keeping mock auth for local UI work
+- Residual risk: Client-console logs are not a durable SIEM; acceptable for this pilot per CP1
 
 ## Test approach
 
-- Cover `features/auth-001-pkce.feature` scenarios in unit tests:
-  - Real path: init called with options including PKCE S256 (spy/mock Keycloak constructor/adapter)
-  - Mock path: adapter `init` not used for PKCE when local mock auth is active
+- Cover `features/log-003-auth-denial-logging.feature`:
+  - Unauthorized → `warn` called with path + reason; redirect to `/unauthorized`
+  - Admin-only denial (e.g. lock-records) → `warn` called with path + reason; redirect to `/`
 - CI: `yarn lint` + `yarn test-ci` on the implementation PR
 - Update `docs/pr-evidence.md` on the implementation PR
 
@@ -48,7 +49,7 @@ App bootstrap
 
 - Ship with next admin UI deploy
 - No data migration
-- Optional human smoke: real IDIR login on a lower environment after deploy
+- Optional human smoke: trigger an unauthorized or non-admin admin-route hit locally / lower env and confirm warn appears when log level allows
 
 ## Approval (checkpoint 2) — **human required**
 
@@ -57,4 +58,4 @@ App bootstrap
 | Architect / tech lead | | |
 | Security (if required) | | |
 
-> Do not add `ready-for-agent` to #11 until this table is filled and this plan PR is merged.
+> Do not add `ready-for-agent` to #15 until this table is filled and this plan PR is merged.

--- a/spec/tasks.md
+++ b/spec/tasks.md
@@ -1,26 +1,31 @@
-# Tasks — PKCE on Keycloak init (AUTH-001)
+# Tasks — Auth denial logging (LOG-003)
 
-Derive from `spec/spec.md` + `features/auth-001-pkce.feature`. Issue: [#11](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/11).
+Derive from `spec/spec.md` + `features/log-003-auth-denial-logging.feature`. Issue: [#15](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/15).
 
-## Milestone 1 — Enable PKCE (after checkpoint 2 approval)
+## Milestone 1 — Log AuthGuard denials (after checkpoint 2 approval)
 
-- [ ] **TASK-001** — Change real Keycloak `init({})` to include `pkceMethod: 'S256'` in `KeycloakService` — covers scenario *Real Keycloak init enables PKCE S256*
-- [ ] **TASK-002** — Add/extend unit tests proving init options include PKCE S256 on the real-auth path, and that local mock auth does not require Keycloak PKCE init — covers both feature scenarios
-- [ ] **TASK-003** — Run `yarn lint` and `yarn test-ci`; update `docs/pr-evidence.md` on the implementation PR
-- [ ] **TASK-004** — Open **draft** PR linking #11; do not self-merge
+- [ ] **TASK-001** — Inject `LoggerService` into `AuthGuard` (`src/app/guards/auth.guard.ts`) and call `warn` before each authorization-failure redirect (`isAuthorized` false → `/unauthorized`; each `isAllowed` failure → `/`) — covers both feature scenarios
+- [ ] **TASK-002** — Include requested path (path-only) and denial reason in the warn message; add a stable identity hint when available without logging the raw token
+- [ ] **TASK-003** — Extend `src/app/guards/auth.guard.spec.ts` so both scenarios assert `LoggerService.warn` was called with path + reason
+- [ ] **TASK-004** — Run `yarn lint` and `yarn test-ci`; update `docs/pr-evidence.md` on the implementation PR
+- [ ] **TASK-005** — Open **draft** PR linking #15; do not self-merge
 
 ## After checkpoint 2 merge (human)
 
-- [ ] Add label `ready-for-agent` to #11 **or** implement locally from this task list
+- [ ] Add label `ready-for-agent` to #15 **or** implement locally from this task list
 - [ ] Approve waiting Actions on the draft PR; review; merge (checkpoint 3)
 
-## Completed (prior slice)
+## Completed (prior slices)
 
 - [x] AUTHZ-001 — AuthGuard path matching (#6) — shipped
+- [x] AUTH-001 — PKCE S256 on Keycloak init (#11) — shipped
 
 ## Backlog (not this slice)
 
 - [ ] AUTH-003 — Logout
 - [ ] AUTH-004 — Token refresh failure UX
 - [ ] AUTH-007 — Bearer host allowlist
-- [ ] LOG-003 — Log authorization denials
+- [ ] LOG-001 — Config object console dump
+- [ ] LOG-002 — Keycloak lifecycle log levels
+- [ ] LOG-004 — LoggerService default Off
+- [ ] AUTHZ-002 — Dead export-reports / review-data guards


### PR DESCRIPTION
## Summary

- Plan + tasks for [#15](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/15) / RA LOG-003
- Realizes signed `spec/features/log-003-auth-denial-logging.feature`

## Checkpoint

Checkpoint **2** — tech lead review before `ready-for-agent`.


Made with [Cursor](https://cursor.com)