### PR TITLE
docs(plan): LOG-001 no config console dump (checkpoint 2)

### DIFF
--- a/spec/plan.md
+++ b/spec/plan.md
@@ -1,47 +1,44 @@
-# Plan — Auth denial logging (LOG-003)
+# Plan — No full config console dump (LOG-001)
 
-> Architecture and delivery approach for issue [#15](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/15) / RA LOG-003.  
+> Architecture and delivery approach for issue [#19](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/19) / RA LOG-001.  
 > Checkpoint 1 (spec) is merged. This document is **checkpoint 2**.
 
 ## Summary
 
-Inject `LoggerService` into `AuthGuard` and emit `warn` **before** each authorization-failure redirect (`/unauthorized` or home `/` for admin-only routes). Log payload includes requested path, denial reason, and a stable identity hint when available. Prove via unit tests with a `LoggerService` spy. No server-side audit API, no route-policy changes, no UI.
+Remove the `console.log('Configuration:', this.configuration)` block in `ConfigService.init()` that fires when `logLevel === 0`. Prove with unit tests that `console.log` is not used to dump the full config object (verbose and non-verbose paths). No sanitized dump, no LOG-004, no UI.
 
 ## Architecture
 
 ```text
-Router navigation
-  → AuthGuard.canActivate(route, state)
-       ├─ not authenticated → login / IdP (unchanged; not this slice)
-       ├─ not authorized → logger.warn(...) → /unauthorized
-       ├─ admin-only denied → logger.warn(...) → /
-       └─ allowed → true
+App bootstrap
+  → ConfigService.init()
+       ├─ load window.__env (± remote /config)
+       ├─ previously: if logLevel === 0 → console.log(full config)  ← remove
+       └─ return
 ```
 
 ## Key decisions
 
 | Decision | Choice | Rationale |
 | --- | --- | --- |
-| Where to log | `AuthGuard` at each authz-failure redirect | Matches finding location; minimal blast radius |
-| Log level | `LoggerService.warn` | Visible above typical info/debug; matches signed spec |
-| Identity hint | Prefer existing Keycloak helpers (e.g. username/preferred_username/sub if already exposed); never log raw JWT or full config | Privacy; constitution-friendly |
-| Path in log | Use same path-only form as AUTHZ-001 (`requestPath`) | Consistent with guard matching |
-| Server audit | Out of scope | Explicit CP1 acceptance for pilot |
-| Log-level residual | Environments with `LogLevel.Off` still won’t print (LOG-004) | Document; do not fix LOG-004 here |
-| Verification | Extend `auth.guard.spec.ts` | CI without live IdP |
+| Where to change | `ConfigService.init()` in `src/app/services/config.service.ts` | Matches finding location |
+| Replacement dump | None | CP1 accepted remove-entirely |
+| Tests | Extend `config.service.spec.ts`; spy `console.log` | CI without live config endpoint |
+| Remote config fetch | Unchanged | Out of scope |
+| LOG-004 default Off | Unchanged | Separate finding |
 
 ## Security & privacy
 
 - Classification: Internal staff UI
-- PIA: No new data collection; only session-derived identity hints already available to the guard
-- Secrets: None
-- Residual risk: Client-console logs are not a durable SIEM; acceptable for this pilot per CP1
+- PIA: No new data collection; we stop exposing config in DevTools
+- Secrets: None added
+- Residual: Other `console.log` / debug paths may still leak fragments (LOG-005 etc.)
 
 ## Test approach
 
-- Cover `features/log-003-auth-denial-logging.feature`:
-  - Unauthorized → `warn` called with path + reason; redirect to `/unauthorized`
-  - Admin-only denial (e.g. lock-records) → `warn` called with path + reason; redirect to `/`
+- Cover `features/log-001-no-config-console-dump.feature`:
+  - `logLevel === 0` after init → `console.log` not called with the full configuration dump (`'Configuration:'` / the config object)
+  - non-zero / undefined logLevel → still no dump
 - CI: `yarn lint` + `yarn test-ci` on the implementation PR
 - Update `docs/pr-evidence.md` on the implementation PR
 
@@ -49,7 +46,7 @@ Router navigation
 
 - Ship with next admin UI deploy
 - No data migration
-- Optional human smoke: trigger an unauthorized or non-admin admin-route hit locally / lower env and confirm warn appears when log level allows
+- Optional human smoke: local start with verbose logLevel, confirm DevTools has no full config dump
 
 ## Approval (checkpoint 2) — **human required**
 
@@ -58,4 +55,4 @@ Router navigation
 | Architect / tech lead | | |
 | Security (if required) | | |
 
-> Do not add `ready-for-agent` to #15 until this table is filled and this plan PR is merged.
+> Do not add `ready-for-agent` to #19 until this table is filled and this plan PR is merged.

--- a/spec/tasks.md
+++ b/spec/tasks.md
@@ -1,18 +1,17 @@
-# Tasks — Auth denial logging (LOG-003)
+# Tasks — No full config console dump (LOG-001)
 
-Derive from `spec/spec.md` + `features/log-003-auth-denial-logging.feature`. Issue: [#15](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/15).
+Derive from `spec/spec.md` + `features/log-001-no-config-console-dump.feature`. Issue: [#19](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/19).
 
-## Milestone 1 — Log AuthGuard denials (after checkpoint 2 approval)
+## Milestone 1 — Stop config dump (after checkpoint 2 approval)
 
-- [ ] **TASK-001** — Inject `LoggerService` into `AuthGuard` (`src/app/guards/auth.guard.ts`) and call `warn` before each authorization-failure redirect (`isAuthorized` false → `/unauthorized`; each `isAllowed` failure → `/`) — covers both feature scenarios
-- [ ] **TASK-002** — Include requested path (path-only) and denial reason in the warn message; add a stable identity hint when available without logging the raw token
-- [ ] **TASK-003** — Extend `src/app/guards/auth.guard.spec.ts` so both scenarios assert `LoggerService.warn` was called with path + reason
-- [ ] **TASK-004** — Run `yarn lint` and `yarn test-ci`; update `docs/pr-evidence.md` on the implementation PR
-- [ ] **TASK-005** — Open **draft** PR linking #15; do not self-merge
+- [ ] **TASK-001** — Remove the `console.log('Configuration:', this.configuration)` block in `ConfigService.init()` (`src/app/services/config.service.ts`) — covers both feature scenarios
+- [ ] **TASK-002** — Extend `src/app/services/config.service.spec.ts`: spy `console.log`; assert no full-config dump when `logLevel === 0` and when logLevel is not All
+- [ ] **TASK-003** — Run `yarn lint` and `yarn test-ci`; update `docs/pr-evidence.md` on the implementation PR
+- [ ] **TASK-004** — Open **draft** PR linking #19; do not self-merge
 
 ## After checkpoint 2 merge (human)
 
-- [ ] Add label `ready-for-agent` to #15 **or** implement locally from this task list
+- [ ] Add label `ready-for-agent` to #19 **or** implement locally from this task list
 - [ ] Approve waiting Actions on the draft PR; review; merge (checkpoint 3)
 
 ## Completed (prior slices)
@@ -20,12 +19,12 @@ Derive from `spec/spec.md` + `features/log-003-auth-denial-logging.feature`. Iss
 - [x] AUTHZ-001 — AuthGuard path matching (#6) — shipped
 - [x] AUTH-001 — PKCE S256 on Keycloak init (#11) — shipped
 
+## In flight (not this slice)
+
+- [ ] LOG-003 — AuthGuard denial logging (#15 / PR #18)
+
 ## Backlog (not this slice)
 
-- [ ] AUTH-003 — Logout
-- [ ] AUTH-004 — Token refresh failure UX
-- [ ] AUTH-007 — Bearer host allowlist
-- [ ] LOG-001 — Config object console dump
 - [ ] LOG-002 — Keycloak lifecycle log levels
 - [ ] LOG-004 — LoggerService default Off
-- [ ] AUTHZ-002 — Dead export-reports / review-data guards
+- [ ] AUTH-003 — Logout


### PR DESCRIPTION
## Summary

- Plan + tasks for [#19](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/19) / RA LOG-001
- Realizes signed `spec/features/log-001-no-config-console-dump.feature`

## Checkpoint

Checkpoint **2** — tech lead review before `ready-for-agent`.


Made with [Cursor](https://cursor.com)