### PR TITLE
docs(plan): CRYPTO-001 CloudFront TLS minimum (checkpoint 2)

### DIFF
--- a/spec/plan.md
+++ b/spec/plan.md
@@ -1,64 +1,51 @@
-# Plan — Keycloak lifecycle log levels (LOG-002)
+# Plan — CloudFront viewer TLS minimum (CRYPTO-001)
 
-> Architecture and delivery approach for issue [#23](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/23) / RA LOG-002.  
+> Architecture and delivery approach for issue [#27](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/27) / RA CRYPTO-001 (alias CONFIG-001).  
 > Checkpoint 1 (spec) is merged. This document is **checkpoint 2**.
 
 ## Summary
 
-Raise `onAuthError`, `onAuthRefreshError`, and `onAuthLogout` in `KeycloakService.init()` from `loggerService.debug()` to `warn` or `error`. Optionally include `getUsername()` as an identity hint. Prove with unit tests that invoke the callbacks. No server audit API, no LOG-004, no AUTH-003 logout UI.
+Change CloudFront `ViewerCertificate.MinimumProtocolVersion` from `TLSv1` to `TLSv1.2_2021` in `template.yaml`. Prove with a static assertion that `TLSv1` is not the viewer minimum. No header policy work. Live TLS handshake after deploy is residual smoke.
 
 ## Architecture
 
 ```text
-KeycloakService.init()  (real path only; mock auth short-circuits)
-  → new Keycloak(config)
-  → callbacks:
-       onAuthSuccess        → debug (unchanged)
-       onAuthError          → warn/error  ← raise
-       onAuthRefreshSuccess → debug (unchanged)
-       onAuthRefreshError   → warn/error  ← raise
-       onAuthLogout         → warn/error  ← raise
-  → init({ pkceMethod: 'S256' })  (AUTH-001, unchanged)
+template.yaml
+  CloudFrontDistribution
+    ViewerCertificate
+      MinimumProtocolVersion: TLSv1          ← remove
+      MinimumProtocolVersion: TLSv1.2_2021   ← set
 ```
 
 ## Key decisions
 
 | Decision | Choice | Rationale |
 | --- | --- | --- |
-| Where to change | `src/app/services/keycloak.service.ts` lifecycle callbacks | Matches finding location |
-| Levels | `warn` or `error` for error + logout; success stays debug | Visible when debug is off; success noise stays quiet |
-| Identity hint | `getUsername()` when non-empty | Already shipped with LOG-003; no extra PII |
-| Server audit | None | Out of scope; residual risk named |
-| Mock auth | Unchanged | No Keycloak init; callbacks never attach |
-| Tests | Extend `keycloak.service.spec.ts`; spy LoggerService | CI without live IdP |
+| Policy | `TLSv1.2_2021` | Assessment recommended; modern ciphers, TLS 1.2+ |
+| File | `template.yaml` only | Matches finding |
+| Headers | Unchanged | CONFIG-002/003/004 |
+| Tests | Static check (grep/script or documented one-line + CI lint) | No live AWS in `yarn test-ci` |
+| Duplicate | Do not file CONFIG-001 | Same defect |
 
 ## Security & privacy
 
-- Classification: Internal staff UI
-- PIA: No new data collection; username already on the JWT
-- Secrets: None added; do not log tokens
-- Residual: Client console only; LOG-004 default Off can still silence logs if `logLevel` is unset; no server-side audit
+- Residual: old TLS clients cannot connect (acceptable). Runtime handshake not verified in CI.
 
 ## Test approach
 
-- Cover `features/log-002-keycloak-lifecycle-log-levels.feature`:
-  - After real `init()`, fire `onAuthError` → `warn` or `error` called
-  - Fire `onAuthRefreshError` → `warn` or `error` called
-  - Fire `onAuthLogout` → `warn` or `error` called
-  - When username stubbed, message includes identity hint (at least for auth error)
-- CI: `yarn lint` + `yarn test-ci` on the implementation PR
-- Update `docs/pr-evidence.md` on the implementation PR
+- Template contains `MinimumProtocolVersion: TLSv1.2_2021` (or `_2019`) and not viewer `TLSv1`
+- Optional: small node/shell check in CI if easy; otherwise evidence + human review of the one-line diff is enough with existing PR Checks (template still parses)
+- Update `docs/pr-evidence.md`
 
 ## Rollout
 
-- Ship with next admin UI deploy
-- Optional human smoke: real IDIR login failure / logout and confirm DevTools warn/error (not blocking CI)
+- Takes effect on next SAM/CloudFront deploy
+- Human smoke after deploy: TLS 1.0 client rejected (optional)
 
 ## Approval (checkpoint 2) — **human required**
 
 | Role | Name | Date |
 | --- | --- | --- |
 | Architect / tech lead | | |
-| Security (if required) | | |
 
-> Do not add `ready-for-agent` to #23 until this table is filled and this plan PR is merged.
+> Do not add `ready-for-agent` to #27 until this plan PR is merged.

--- a/spec/tasks.md
+++ b/spec/tasks.md
@@ -1,27 +1,23 @@
-# Tasks — Keycloak lifecycle log levels (LOG-002)
+# Tasks — CloudFront viewer TLS minimum (CRYPTO-001)
 
-Derive from `spec/spec.md` + `features/log-002-keycloak-lifecycle-log-levels.feature`. Issue: [#23](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/23).
+Derive from `spec/spec.md` + `features/crypto-001-cloudfront-tls-minimum.feature`. Issue: [#27](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/27).
 
-## Milestone 1 — Raise lifecycle log levels (after checkpoint 2 approval)
+## Milestone 1 — Raise TLS floor (after checkpoint 2 approval)
 
-- [ ] **TASK-001** — In `src/app/services/keycloak.service.ts`, change `onAuthError`, `onAuthRefreshError`, and `onAuthLogout` from `loggerService.debug(...)` to `warn` or `error`; include `getUsername()` identity hint when non-empty. Leave success callbacks at debug. Do not change mock-auth short-circuit or PKCE init.
-- [ ] **TASK-002** — Extend `src/app/services/keycloak.service.spec.ts`: after real `init()`, invoke the three callbacks; spy `LoggerService.warn`/`error`; cover identity hint on auth error.
-- [ ] **TASK-003** — Run `yarn lint` and `yarn test-ci`; update `docs/pr-evidence.md` on the implementation PR
-- [ ] **TASK-004** — Open **draft** PR linking #23; do not self-merge
+- [ ] **TASK-001** — In `template.yaml` `ViewerCertificate`, set `MinimumProtocolVersion: TLSv1.2_2021` (replace `TLSv1`). Do not change ResponseHeadersPolicyId, origins, or certificate ARN.
+- [ ] **TASK-002** — Prove statically (comment/grep in evidence, or a tiny test/script) that the viewer minimum is not `TLSv1`
+- [ ] **TASK-003** — Update `docs/pr-evidence.md`; open **draft** PR linking #27; do not self-merge
 
 ## After checkpoint 2 merge (human)
 
-- [ ] Add label `ready-for-agent` to #23 **or** implement locally from this task list
-- [ ] Approve waiting Actions on the draft PR; review; merge (checkpoint 3)
+- [ ] Add label `ready-for-agent` to #27
+- [ ] Review; merge (checkpoint 3). Post-deploy TLS smoke is residual.
 
 ## Completed (prior slices)
 
-- [x] AUTHZ-001 — AuthGuard path matching (#6) — shipped
-- [x] AUTH-001 — PKCE S256 on Keycloak init (#11) — shipped
-- [x] LOG-001 — No config console dump (#19) — shipped
-- [x] LOG-003 — AuthGuard denial logging (#15) — shipped
+- [x] AUTHZ-001 (#6), AUTH-001 (#11), LOG-001 (#19), LOG-003 (#15), LOG-002 (#23)
 
 ## Backlog (not this slice)
 
-- [ ] LOG-004 — LoggerService default Off
-- [ ] AUTH-003 — Logout
+- [ ] CONFIG-003 HSTS, CONFIG-004 headers, CONFIG-002 CSP
+- [ ] SECRET-001


### PR DESCRIPTION
## Summary

- Plan + tasks for [#27](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/27) / RA CRYPTO-001
- Realizes signed `spec/features/crypto-001-cloudfront-tls-minimum.feature`

## Checkpoint

Checkpoint **2** — tech lead review before `ready-for-agent`.


Made with [Cursor](https://cursor.com)