### PR TITLE
docs(spec): CONFIG-002 CloudFront CSP (checkpoint 1)

### DIFF
--- a/spec/features/config-002-cloudfront-csp.feature
+++ b/spec/features/config-002-cloudfront-csp.feature
@@ -1,0 +1,16 @@
+Feature: Content-Security-Policy on CloudFront responses
+  As a security-conscious operator of the A&R Admin UI
+  I want browsers to only load scripts and connections we allow
+  So that injected script and unexpected third-party hosts are blocked
+
+  # Finding: RA CONFIG-002 · Issue: #41
+  # Verification: static template check; post-deploy login/API header probe is residual
+
+  Scenario: Shared policy contains a sourced Content-Security-Policy
+    Given all three cache behaviors reference the shared response policy
+    When that policy is inspected
+    Then it sets Content-Security-Policy
+    And script sources are limited to the same origin
+    And connect and frame sources allow loginproxy and the attendance API hosts
+    And object sources are none and frame ancestors are none
+    And HSTS, CORS, and CONFIG-004 browser headers remain configured

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -5,56 +5,83 @@
 
 ---
 
-## Active slice — CONFIG-004 (browser security headers)
+## Active slice — CONFIG-002 (Content-Security-Policy)
 
-**Issue:** [#36](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/36)  
-**Finding:** RA CONFIG-004  
-**Feature:** `features/config-004-cloudfront-security-headers.feature`
+**Issue:** [#41](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/41)  
+**Finding:** RA CONFIG-002  
+**Feature:** `features/config-002-cloudfront-csp.feature`
 
 ### Problem
 
-CloudFront responses do not prevent framing or MIME sniffing, do not constrain referrer detail, and do not disable unused browser capabilities. This weakens browser-side protection for the authenticated admin UI.
+Responses from the admin UI host do not tell the browser which script, style, image, font, connect, or frame sources are allowed. Without that policy, injected script can run, and the Keycloak login host is not an explicit allowlisted partner.
 
 ### Outcome
 
-The shared CloudFront response policy adds frame denial, nosniff, strict-origin-when-cross-origin referrer handling, and a restrictive permissions policy. HSTS and CORS from CONFIG-003 remain. CSP is a separate later slice.
+The shared response-headers policy emits a Content-Security-Policy whose allowlist matches how this app actually loads:
+
+- First-party UI assets (scripts, styles, images, fonts) from the same host
+- API calls to the configured attendance API host (same host via `/api`, API Gateway, or `*.bcparks.ca`)
+- Keycloak / loginproxy (`loginproxy.gov.bc.ca` and `*.loginproxy.gov.bc.ca`) for token/XHR, silent-check iframe, and login navigation
+- Inline styles required by the current UI libraries
+- No plugins (`object-src` none); no embedding this app in other sites (`frame-ancestors` none)
+
+HSTS, CORS, and the CONFIG-004 browser headers remain. Proof is structural inspection of the hosting template. Live login/API smoke after deploy is residual.
 
 ### Users & personas
 
 | Persona | Goal |
 | --- | --- |
-| BC Parks staff | App and API continue working normally |
-| Security reviewer | Confirm the four protections are emitted by the shared policy |
+| BC Parks staff | Login, API calls, and the UI continue to work after CSP is on |
+| Security reviewer | Confirm CSP is present on the shared policy with a sourced allowlist |
 | Platform operator | Extend the existing policy; keep three behavior attachments |
 
 ### Scope
 
-#### In scope (#36)
+#### In scope (#41)
 
-- Frame protection, nosniff, Referrer-Policy, Permissions-Policy
-- Preserve HSTS/CORS and all three attachments
+- CSP on the existing shared response-headers policy
+- Allowlist derived from SPA assets, API `connect-src`, and Keycloak/loginproxy (see below)
+- Preserve HSTS, CORS, and CONFIG-004 headers and all three attachments
 - Static template proof
 
 #### Out of scope
 
-- CSP (CONFIG-002)
-- App UI/API changes
-- Live deploy/header probe in CI
+- New response-headers policy
+- App UI/API/Keycloak client changes
+- Nonce/hash-based `script-src` or removing `'unsafe-inline'` from styles in this slice
+- Live deploy / login smoke in CI
+
+### Derived allowlist (pre-plan)
+
+Reviewed `src/index.html`, `angular.json` (bundled jQuery/Bootstrap/Popper/keycloak-js — not a CDN), `src/styles.scss` (Bootstrap Icons fonts), `src/env.js` / deploy workflows (`API_LOCATION`, `KEYCLOAK_URL`), and Keycloak init (token XHR + possible silent iframe).
+
+| Directive | Sources | Why |
+| --- | --- | --- |
+| `default-src` / `script-src` / `base-uri` | `'self'` | Bundled SPA + `env.js`; Keycloak JS is npm-bundled, not loaded from loginproxy |
+| `style-src` | `'self' 'unsafe-inline'` | Angular/component styles, ngx-bootstrap datepicker, ngx-toastr |
+| `img-src` / `font-src` | `'self' data:` | Local assets + Bootstrap Icons |
+| `connect-src` | `'self'` + loginproxy + `*.execute-api.ca-central-1.amazonaws.com` + `*.bcparks.ca` | API via `API_LOCATION`; Keycloak token/userinfo |
+| `frame-src` | loginproxy hosts | Keycloak silent SSO iframe |
+| `form-action` | `'self'` + loginproxy hosts | Login redirect/form |
+| `object-src` | `'none'` | No plugins |
+| `frame-ancestors` | `'none'` | Complements CONFIG-004 frame denial |
+
+Exact header string is a checkpoint 2 decision. CSP host wildcards: `https://*.loginproxy.gov.bc.ca` does **not** match apex `https://loginproxy.gov.bc.ca` — both must be listed.
 
 ### Journeys
 
-1. Shared policy contains browser protections — see `features/config-004-cloudfront-security-headers.feature`
+1. Shared policy contains CSP with the derived allowlist — see `features/config-002-cloudfront-csp.feature`
 
 ### Non-functional requirements
 
 - No UI change; AWS hosting remains
-- Static proof in evidence; post-deploy smoke residual
+- Static proof in evidence; post-deploy login/API header smoke residual
 
 ### Traceability
 
 | Finding | Issue | Feature |
 | --- | --- | --- |
-| RA CONFIG-004 | #36 | `features/config-004-cloudfront-security-headers.feature` |
+| RA CONFIG-002 | #41 | `features/config-002-cloudfront-csp.feature` |
 
 ### Sign-off (checkpoint 1) — **human required**
 
@@ -64,18 +91,22 @@ The shared CloudFront response policy adds frame denial, nosniff, strict-origin-
 | Tech lead | | |
 | QA | | |
 
-> Do not add `ready-for-agent` to #36 until this spec PR is merged.
+> Do not add `ready-for-agent` to #41 until this spec PR is merged.
 
 ---
 
 ## Completed slices
+
+### CONFIG-004 — Browser security headers
+
+- **Issue:** [#36](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/36) (shipped)
+- **Feature:** `features/config-004-cloudfront-security-headers.feature`
 
 ### CONFIG-003 — CloudFront HSTS
 
 - **Issue:** [#32](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/32) (shipped)
 - **Feature:** `features/config-003-cloudfront-hsts.feature`
 
-### CONFIG-003 — CloudFront HSTS — [#32](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/32)
 ### CRYPTO-001 — Viewer TLS 1.2+ — [#27](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/27)
 ### LOG-002 — Keycloak lifecycle levels — [#23](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/23)
 ### LOG-003 — Auth denial logging — [#15](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/15)


### PR DESCRIPTION
## Summary
- Plan + Gherkin for [#41](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/41) / RA CONFIG-002
- Allowlist derived from first-party SPA assets, API `connect-src`, and Keycloak/loginproxy
- CSP is last on the existing shared response-headers policy; HSTS/CORS/CONFIG-004 stay

Fixes #41 (docs only — implementation follows checkpoint 2)

## Checkpoint
Checkpoint 1 (spec). Do not label `ready-for-agent` until plan is signed.

Made with [Cursor](https://cursor.com)