### PR TITLE
docs(plan): CONFIG-002 CloudFront CSP (checkpoint 2)

### DIFF
--- a/spec/plan.md
+++ b/spec/plan.md
@@ -1,11 +1,11 @@
-# Plan — CloudFront browser security headers (CONFIG-004)
+# Plan — CloudFront Content-Security-Policy (CONFIG-002)
 
-> Architecture and delivery approach for issue [#36](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/36) / RA CONFIG-004.  
+> Architecture and delivery approach for issue [#41](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/41) / RA CONFIG-002.  
 > Checkpoint 1 (spec) is merged. This document is **checkpoint 2**.
 
 ## Summary
 
-Extend the existing `CloudFrontHSTSResponseHeadersPolicy` (CONFIG-003) with frame denial, nosniff, Referrer-Policy, and Permissions-Policy. Keep HSTS and CORS. Do not add CSP in this slice.
+Add CSP to the existing `CloudFrontHSTSResponseHeadersPolicy`. Keep HSTS, CORS, and CONFIG-004 headers. Do not create a second policy. Live login/API smoke is residual, not a merge gate.
 
 ## Architecture
 
@@ -13,43 +13,51 @@ Extend the existing `CloudFrontHSTSResponseHeadersPolicy` (CONFIG-003) with fram
 template.yaml
   CloudFrontHSTSResponseHeadersPolicy (existing)
     SecurityHeadersConfig
-      StrictTransportSecurity          ← keep (CONFIG-003)
-      FrameOptions: DENY               ← new
-      ContentTypeOptions: nosniff      ← new
-      ReferrerPolicy: strict-origin-when-cross-origin  ← new
-    CustomHeadersConfig
-      Permissions-Policy               ← new (not a first-class SecurityHeadersConfig field)
-    CorsConfig                         ← keep
+      StrictTransportSecurity, FrameOptions, ContentTypeOptions, ReferrerPolicy  ← keep
+      ContentSecurityPolicy.ContentSecurityPolicy  ← new (string below)
+    CustomHeadersConfig.Permissions-Policy         ← keep
+    CorsConfig                                     ← keep
   CloudFrontDistribution
     all three cache behaviours already !Ref this policy — leave attachments as-is
 ```
+
+## Locked CSP string
+
+Derived in checkpoint 1 from `src/index.html`, `angular.json` (bundled jQuery/Bootstrap/Popper/`keycloak-js`, not a CDN), `src/styles.scss` (Bootstrap Icons), `API_LOCATION` / deploy `API_GATEWAY_URL`, and Keycloak `KEYCLOAK_URL` (`dev.loginproxy.gov.bc.ca` / `loginproxy.gov.bc.ca`). Apex `loginproxy.gov.bc.ca` is listed separately because `*.loginproxy.gov.bc.ca` does not match it.
+
+```
+default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://*.loginproxy.gov.bc.ca https://loginproxy.gov.bc.ca https://*.execute-api.ca-central-1.amazonaws.com https://*.bcparks.ca; frame-src https://*.loginproxy.gov.bc.ca https://loginproxy.gov.bc.ca; form-action 'self' https://*.loginproxy.gov.bc.ca https://loginproxy.gov.bc.ca
+```
+
+CloudFront native field: `SecurityHeadersConfig.ContentSecurityPolicy` with `Override: true`.
 
 ## Key decisions
 
 | Decision | Choice | Rationale |
 | --- | --- | --- |
-| Where | Extend `CloudFrontHSTSResponseHeadersPolicy` | One policy, three attachments already in place |
-| Frame | `FrameOption: DENY` | Admin UI is not framed |
-| MIME | `ContentTypeOptions.Override: true` | CloudFront emits `X-Content-Type-Options: nosniff` |
-| Referrer | `strict-origin-when-cross-origin` | Signed Gherkin |
-| Permissions | Custom header disabling unused capabilities (camera, microphone, geolocation, payment, usb, interest-cohort) | No native `PermissionsPolicy` property on this resource |
-| CSP | Not this PR | CONFIG-002 |
+| Where | Extend existing policy | Three attachments already in place |
+| `script-src` | `'self'` only | Keycloak JS is npm-bundled via `angular.json` scripts |
+| `style-src` | include `'unsafe-inline'` | Angular / ngx-bootstrap / ngx-toastr; nonce migration is later |
+| API hosts | `'self'` + execute-api + `*.bcparks.ca` | `API_LOCATION` may be CloudFront `/api`, execute-api, or custom domain |
+| IdP | both apex and `*.loginproxy.gov.bc.ca` | token XHR, silent iframe, login navigation |
 | Proof | Static template assertions | No live AWS in CI |
+| Live smoke | Residual after deploy | Not required to merge CP3 |
 
 ## Security & privacy
 
-- Residual: headers take effect only after the next CloudFront deploy. Live `curl -I` / browser DevTools header smoke is a human follow-up, not a CI gate.
-- Clickjacking/MIME/referrer controls are browser-enforced; they do not replace API authorization.
+- Residual: headers take effect only after the next CloudFront deploy. Human follow-up: `curl -I` for `Content-Security-Policy` plus a login + one API call watching the console for CSP violations.
+- CSP is browser-enforced; it does not replace API authorization.
+- `'unsafe-inline'` on styles is an accepted residual for this slice.
 
 ## Test approach
 
-- Static: `template.yaml` contains FrameOptions DENY, ContentTypeOptions, ReferrerPolicy `strict-origin-when-cross-origin`, and a Permissions-Policy custom header; HSTS + CORS remain; all three behaviours still `!Ref CloudFrontHSTSResponseHeadersPolicy`
+- Static: `template.yaml` `ContentSecurityPolicy` contains the locked string (or equivalent directives); HSTS + CORS + CONFIG-004 headers remain; all three behaviours still `!Ref CloudFrontHSTSResponseHeadersPolicy`
 - Update `docs/pr-evidence.md`
 - No Angular/UI tests required
 
 ## Rollout
 
-- Next SAM deploy. Optional human: `curl -I` for `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, plus HSTS.
+- Next SAM deploy. Optional human: header probe + IDIR login + one API request.
 
 ## Approval (checkpoint 2) — **human required**
 

--- a/spec/plan.md
+++ b/spec/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Add CSP to the existing `CloudFrontHSTSResponseHeadersPolicy`. Keep HSTS, CORS, and CONFIG-004 headers. Do not create a second policy. Live login/API smoke is residual, not a merge gate.
+Add `ContentSecurityPolicy` to the existing `CloudFrontHSTSResponseHeadersPolicy`. Keep HSTS, CORS, and CONFIG-004 headers. Do not create a second policy. Live login/API smoke is residual, not a merge gate.
 
 ## Architecture
 
@@ -13,51 +13,59 @@ Add CSP to the existing `CloudFrontHSTSResponseHeadersPolicy`. Keep HSTS, CORS, 
 template.yaml
   CloudFrontHSTSResponseHeadersPolicy (existing)
     SecurityHeadersConfig
-      StrictTransportSecurity, FrameOptions, ContentTypeOptions, ReferrerPolicy  ← keep
-      ContentSecurityPolicy.ContentSecurityPolicy  ← new (string below)
-    CustomHeadersConfig.Permissions-Policy         ← keep
-    CorsConfig                                     ← keep
+      ContentSecurityPolicy            ← new (CONFIG-002)
+      FrameOptions / ContentTypeOptions / ReferrerPolicy / HSTS  ← keep
+    CustomHeadersConfig
+      Permissions-Policy               ← keep
+    CorsConfig                         ← keep
   CloudFrontDistribution
     all three cache behaviours already !Ref this policy — leave attachments as-is
 ```
 
-## Locked CSP string
+## CSP header (signed allowlist)
 
-Derived in checkpoint 1 from `src/index.html`, `angular.json` (bundled jQuery/Bootstrap/Popper/`keycloak-js`, not a CDN), `src/styles.scss` (Bootstrap Icons), `API_LOCATION` / deploy `API_GATEWAY_URL`, and Keycloak `KEYCLOAK_URL` (`dev.loginproxy.gov.bc.ca` / `loginproxy.gov.bc.ca`). Apex `loginproxy.gov.bc.ca` is listed separately because `*.loginproxy.gov.bc.ca` does not match it.
+Exact `ContentSecurityPolicy` string (single line in the template):
 
 ```
-default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://*.loginproxy.gov.bc.ca https://loginproxy.gov.bc.ca https://*.execute-api.ca-central-1.amazonaws.com https://*.bcparks.ca; frame-src https://*.loginproxy.gov.bc.ca https://loginproxy.gov.bc.ca; form-action 'self' https://*.loginproxy.gov.bc.ca https://loginproxy.gov.bc.ca
+default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://loginproxy.gov.bc.ca https://*.loginproxy.gov.bc.ca https://*.execute-api.ca-central-1.amazonaws.com https://*.bcparks.ca; frame-src https://loginproxy.gov.bc.ca https://*.loginproxy.gov.bc.ca; form-action 'self' https://loginproxy.gov.bc.ca https://*.loginproxy.gov.bc.ca; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
 ```
 
-CloudFront native field: `SecurityHeadersConfig.ContentSecurityPolicy` with `Override: true`.
+| Directive | Sources | Why |
+| --- | --- | --- |
+| `script-src` / `default-src` / `base-uri` | `'self'` | Bundled SPA + `env.js`; keycloak-js is npm, not a loginproxy script |
+| `style-src` | `'self' 'unsafe-inline'` | Angular / ngx-bootstrap / toastr inline styles |
+| `img-src` / `font-src` | `'self' data:` | Local assets + Bootstrap Icons |
+| `connect-src` | `'self'` + loginproxy apex+wildcard + `*.execute-api.ca-central-1.amazonaws.com` + `*.bcparks.ca` | `API_LOCATION` (execute-api or CloudFront `/api`) + Keycloak XHR |
+| `frame-src` | loginproxy apex + `*.loginproxy.gov.bc.ca` | Keycloak silent SSO iframe |
+| `form-action` | `'self'` + loginproxy | Login redirect |
+| `object-src` | `'none'` | No plugins |
+| `frame-ancestors` | `'none'` | Complements CONFIG-004 DENY |
+
+CSP `https://*.loginproxy.gov.bc.ca` does **not** match apex `https://loginproxy.gov.bc.ca`; both are required.
 
 ## Key decisions
 
 | Decision | Choice | Rationale |
 | --- | --- | --- |
-| Where | Extend existing policy | Three attachments already in place |
-| `script-src` | `'self'` only | Keycloak JS is npm-bundled via `angular.json` scripts |
-| `style-src` | include `'unsafe-inline'` | Angular / ngx-bootstrap / ngx-toastr; nonce migration is later |
-| API hosts | `'self'` + execute-api + `*.bcparks.ca` | `API_LOCATION` may be CloudFront `/api`, execute-api, or custom domain |
-| IdP | both apex and `*.loginproxy.gov.bc.ca` | token XHR, silent iframe, login navigation |
-| Proof | Static template assertions | No live AWS in CI |
-| Live smoke | Residual after deploy | Not required to merge CP3 |
+| Where | Extend existing policy `SecurityHeadersConfig.ContentSecurityPolicy` with `Override: true` | One policy, three attachments |
+| Mode | Enforcing CSP (not Report-Only) | Finding asks for the header; report-only would not close it |
+| Live smoke | Residual human follow-up after deploy | CI cannot hit loginproxy/API; do **not** block merge on live proof |
+| Nonce/hashes | Out of scope | Would require app rebuild |
 
 ## Security & privacy
 
-- Residual: headers take effect only after the next CloudFront deploy. Human follow-up: `curl -I` for `Content-Security-Policy` plus a login + one API call watching the console for CSP violations.
+- Residual: a too-tight CSP can break IDIR/BCeID/API until the next deploy. If live smoke fails, widen `connect-src`/`frame-src` with evidence — do not add `'unsafe-eval'` or `*` unless a concrete runtime error requires it.
 - CSP is browser-enforced; it does not replace API authorization.
-- `'unsafe-inline'` on styles is an accepted residual for this slice.
 
 ## Test approach
 
-- Static: `template.yaml` `ContentSecurityPolicy` contains the locked string (or equivalent directives); HSTS + CORS + CONFIG-004 headers remain; all three behaviours still `!Ref CloudFrontHSTSResponseHeadersPolicy`
+- Static: template contains `ContentSecurityPolicy` with the directives above; loginproxy apex + wildcard; execute-api ca-central-1; `object-src 'none'`; `frame-ancestors 'none'`; no `ContentSecurityPolicy` Report-Only; HSTS/CORS/CONFIG-004 keys remain; three `!Ref CloudFrontHSTSResponseHeadersPolicy`
 - Update `docs/pr-evidence.md`
-- No Angular/UI tests required
+- No Angular tests required
 
 ## Rollout
 
-- Next SAM deploy. Optional human: header probe + IDIR login + one API request.
+- Next SAM deploy. Optional human: `curl -I` for CSP, then login + one API call. Record failures as residual, not a reason to revert CI-proven template structure.
 
 ## Approval (checkpoint 2) — **human required**
 

--- a/spec/tasks.md
+++ b/spec/tasks.md
@@ -1,27 +1,22 @@
-# Tasks — CloudFront browser security headers (CONFIG-004)
+# Tasks — CloudFront Content-Security-Policy (CONFIG-002)
 
-Derive from `spec/spec.md` + `features/config-004-cloudfront-security-headers.feature`. Issue: [#36](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/36).
+Derive from `spec/spec.md` + `features/config-002-cloudfront-csp.feature`. Issue: [#41](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/41).
 
-## Milestone 1 — Extend shared response policy (after checkpoint 2 approval)
+## Milestone 1 — Add CSP to shared response policy (after checkpoint 2 approval)
 
-- [ ] **TASK-001** — In `template.yaml` `CloudFrontHSTSResponseHeadersPolicy` `SecurityHeadersConfig`, add:
-  - `FrameOptions`: `FrameOption: DENY`, `Override: true`
-  - `ContentTypeOptions`: `Override: true`
-  - `ReferrerPolicy`: `ReferrerPolicy: strict-origin-when-cross-origin`, `Override: true`
-  Keep existing `StrictTransportSecurity`.
-- [ ] **TASK-002** — Add `CustomHeadersConfig` with `Permissions-Policy` disabling unused capabilities (`camera=()`, `microphone=()`, `geolocation=()`, `payment=()`, `usb=()`, `interest-cohort=()`), `Override: true`
-- [ ] **TASK-003** — Keep CORS and all three `ResponseHeadersPolicyId: !Ref CloudFrontHSTSResponseHeadersPolicy` attachments. Do **not** add Content-Security-Policy (CONFIG-002).
-- [ ] **TASK-004** — Update `docs/pr-evidence.md` with static proof; open **draft** PR linking #36 (`Fixes #36`); do not self-merge
+- [ ] **TASK-001** — In `template.yaml` `CloudFrontHSTSResponseHeadersPolicy` `SecurityHeadersConfig`, add `ContentSecurityPolicy` with `Override: true` and the locked CSP string from `spec/plan.md` (script `'self'`; style `'self' 'unsafe-inline'`; img/font `'self' data:`; connect `'self'` + loginproxy + execute-api + `*.bcparks.ca`; frame-src loginproxy; form-action `'self'` + loginproxy; `object-src 'none'`; `frame-ancestors 'none'`; `base-uri 'self'`). Include both `https://loginproxy.gov.bc.ca` and `https://*.loginproxy.gov.bc.ca`.
+- [ ] **TASK-002** — Keep HSTS, CORS, FrameOptions, ContentTypeOptions, ReferrerPolicy, Permissions-Policy, and all three `ResponseHeadersPolicyId: !Ref CloudFrontHSTSResponseHeadersPolicy` attachments. Do **not** create a second policy.
+- [ ] **TASK-003** — Update `docs/pr-evidence.md` with static proof; open **draft** PR linking #41 (`Fixes #41`); do not self-merge
 
 ## After checkpoint 2 merge (human)
 
-- [ ] Label #36 `ready-for-agent`
-- [ ] Review; merge (checkpoint 3). Live header smoke is residual.
+- [ ] Label #41 `ready-for-agent`
+- [ ] Review; merge (checkpoint 3). Live login/API CSP smoke is residual — not a merge gate.
 
 ## Completed (prior slices)
 
-- [x] AUTHZ-001 (#6), AUTH-001 (#11), LOG-001 (#19), LOG-003 (#15), LOG-002 (#23), CRYPTO-001 (#27), CONFIG-003 (#32)
+- [x] AUTHZ-001 (#6), AUTH-001 (#11), LOG-001 (#19), LOG-003 (#15), LOG-002 (#23), CRYPTO-001 (#27), CONFIG-003 (#32), CONFIG-004 (#36)
 
 ## Next (not this slice)
 
-- [ ] CONFIG-002 CSP
+- [ ] SECRET-001 certificate ARN env var

--- a/spec/tasks.md
+++ b/spec/tasks.md
@@ -2,16 +2,16 @@
 
 Derive from `spec/spec.md` + `features/config-002-cloudfront-csp.feature`. Issue: [#41](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/41).
 
-## Milestone 1 — Add CSP to shared response policy (after checkpoint 2 approval)
+## Milestone 1 — CSP on shared policy (after checkpoint 2 approval)
 
-- [ ] **TASK-001** — In `template.yaml` `CloudFrontHSTSResponseHeadersPolicy` `SecurityHeadersConfig`, add `ContentSecurityPolicy` with `Override: true` and the locked CSP string from `spec/plan.md` (script `'self'`; style `'self' 'unsafe-inline'`; img/font `'self' data:`; connect `'self'` + loginproxy + execute-api + `*.bcparks.ca`; frame-src loginproxy; form-action `'self'` + loginproxy; `object-src 'none'`; `frame-ancestors 'none'`; `base-uri 'self'`). Include both `https://loginproxy.gov.bc.ca` and `https://*.loginproxy.gov.bc.ca`.
-- [ ] **TASK-002** — Keep HSTS, CORS, FrameOptions, ContentTypeOptions, ReferrerPolicy, Permissions-Policy, and all three `ResponseHeadersPolicyId: !Ref CloudFrontHSTSResponseHeadersPolicy` attachments. Do **not** create a second policy.
-- [ ] **TASK-003** — Update `docs/pr-evidence.md` with static proof; open **draft** PR linking #41 (`Fixes #41`); do not self-merge
+- [ ] **TASK-001** — In `template.yaml` `CloudFrontHSTSResponseHeadersPolicy` `SecurityHeadersConfig`, add `ContentSecurityPolicy` with `Override: true` and the exact policy string from `spec/plan.md` (script `'self'`; style `'self' 'unsafe-inline'`; img/font `'self' data:`; connect `'self'` + loginproxy apex+wildcard + `*.execute-api.ca-central-1.amazonaws.com` + `*.bcparks.ca`; frame-src loginproxy apex+wildcard; form-action `'self'` + loginproxy; `object-src 'none'`; `frame-ancestors 'none'`; `base-uri 'self'`)
+- [ ] **TASK-002** — Keep HSTS, CORS, CONFIG-004 headers (`FrameOptions`, `ContentTypeOptions`, `ReferrerPolicy`, `Permissions-Policy`) and all three `ResponseHeadersPolicyId: !Ref CloudFrontHSTSResponseHeadersPolicy` attachments. Do **not** add a second policy or Report-Only CSP.
+- [ ] **TASK-003** — Update `docs/pr-evidence.md` with static proof of the directives; open **draft** PR linking #41 (`Fixes #41`); do not self-merge
 
 ## After checkpoint 2 merge (human)
 
 - [ ] Label #41 `ready-for-agent`
-- [ ] Review; merge (checkpoint 3). Live login/API CSP smoke is residual — not a merge gate.
+- [ ] Review; merge (checkpoint 3). Live login/API header smoke is residual — not a merge gate.
 
 ## Completed (prior slices)
 
@@ -19,4 +19,4 @@ Derive from `spec/spec.md` + `features/config-002-cloudfront-csp.feature`. Issue
 
 ## Next (not this slice)
 
-- [ ] SECRET-001 certificate ARN env var
+- [ ] SECRET-001, TEST-001


### PR DESCRIPTION
## Summary
- Plan + tasks for [#41](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/41) / RA CONFIG-002
- Realizes signed `spec/features/config-002-cloudfront-csp.feature`
- Locked CSP string; extend existing policy; structural CI proof; live smoke residual

## Checkpoint
Checkpoint 2 (plan). After merge, label `#41` `ready-for-agent`.

Made with [Cursor](https://cursor.com)