### PR TITLE
docs(plan): SECRET-001 prod cert from environment (checkpoint 2)

### DIFF
--- a/spec/plan.md
+++ b/spec/plan.md
@@ -1,71 +1,50 @@
-# Plan — CloudFront Content-Security-Policy (CONFIG-002)
+# Plan — Production certificate environment input (SECRET-001)
 
-> Architecture and delivery approach for issue [#41](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/41) / RA CONFIG-002.  
+> Architecture and delivery approach for issue [#46](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/46) / RA SECRET-001.  
 > Checkpoint 1 (spec) is merged. This document is **checkpoint 2**.
 
 ## Summary
 
-Add `ContentSecurityPolicy` to the existing `CloudFrontHSTSResponseHeadersPolicy`. Keep HSTS, CORS, and CONFIG-004 headers. Do not create a second policy. Live login/API smoke is residual, not a merge gate.
+Replace the hardcoded `DomainCertificateArn` on the LZA **prod** deploy workflow with `${{ vars.DOMAIN_CERTIFICATE_ARN }}`. Do not reprint the current ARN in evidence or comments. **Do not merge the implementation** until a human has created GitHub Environment `lza-prod` and set that variable — the environment currently 404s via API, so a merge would break prod deploy.
 
 ## Architecture
 
 ```text
-template.yaml
-  CloudFrontHSTSResponseHeadersPolicy (existing)
-    SecurityHeadersConfig
-      ContentSecurityPolicy            ← new (CONFIG-002)
-      FrameOptions / ContentTypeOptions / ReferrerPolicy / HSTS  ← keep
-    CustomHeadersConfig
-      Permissions-Policy               ← keep
-    CorsConfig                         ← keep
-  CloudFrontDistribution
-    all three cache behaviours already !Ref this policy — leave attachments as-is
+.github/workflows/lza-deploy-admin-prod.yaml
+  jobs.deploy.environment: lza-prod          ← already set
+  SAM --parameter-overrides
+    DomainCertificateArn="${{ vars.DOMAIN_CERTIFICATE_ARN }}"  ← new
 ```
 
-## CSP header (signed allowlist)
-
-Exact `ContentSecurityPolicy` string (single line in the template):
-
-```
-default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://loginproxy.gov.bc.ca https://*.loginproxy.gov.bc.ca https://*.execute-api.ca-central-1.amazonaws.com https://*.bcparks.ca; frame-src https://loginproxy.gov.bc.ca https://*.loginproxy.gov.bc.ca; form-action 'self' https://loginproxy.gov.bc.ca https://*.loginproxy.gov.bc.ca; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
-```
-
-| Directive | Sources | Why |
-| --- | --- | --- |
-| `script-src` / `default-src` / `base-uri` | `'self'` | Bundled SPA + `env.js`; keycloak-js is npm, not a loginproxy script |
-| `style-src` | `'self' 'unsafe-inline'` | Angular / ngx-bootstrap / toastr inline styles |
-| `img-src` / `font-src` | `'self' data:` | Local assets + Bootstrap Icons |
-| `connect-src` | `'self'` + loginproxy apex+wildcard + `*.execute-api.ca-central-1.amazonaws.com` + `*.bcparks.ca` | `API_LOCATION` (execute-api or CloudFront `/api`) + Keycloak XHR |
-| `frame-src` | loginproxy apex + `*.loginproxy.gov.bc.ca` | Keycloak silent SSO iframe |
-| `form-action` | `'self'` + loginproxy | Login redirect |
-| `object-src` | `'none'` | No plugins |
-| `frame-ancestors` | `'none'` | Complements CONFIG-004 DENY |
-
-CSP `https://*.loginproxy.gov.bc.ca` does **not** match apex `https://loginproxy.gov.bc.ca`; both are required.
+`vars.*` is scoped to the job `environment`. Until `lza-prod` exists and `DOMAIN_CERTIFICATE_ARN` is set, the expression is empty at runtime.
 
 ## Key decisions
 
 | Decision | Choice | Rationale |
 | --- | --- | --- |
-| Where | Extend existing policy `SecurityHeadersConfig.ContentSecurityPolicy` with `Override: true` | One policy, three attachments |
-| Mode | Enforcing CSP (not Report-Only) | Finding asks for the header; report-only would not close it |
-| Live smoke | Residual human follow-up after deploy | CI cannot hit loginproxy/API; do **not** block merge on live proof |
-| Nonce/hashes | Out of scope | Would require app rebuild |
+| Scope | Prod workflow only | Finding is SECRET-001; dev/test ARNs are SECRET-002 |
+| Source | `${{ vars.DOMAIN_CERTIFICATE_ARN }}` | Signed spec; GitHub Environment variable, not a repo secret (ARN is an identifier, but still must leave the file) |
+| Evidence | Assert `vars.DOMAIN_CERTIFICATE_ARN` present and no literal `arn:aws:acm:` on that override | Do not paste the old value |
+| Merge | **Pause before CP3 merge** | `lza-prod` is not configured (API 404). Human must create the environment and variable |
+| Draft impl | Allowed | Copilot may open a draft PR; leave draft until the env exists |
 
 ## Security & privacy
 
-- Residual: a too-tight CSP can break IDIR/BCeID/API until the next deploy. If live smoke fails, widen `connect-src`/`frame-src` with evidence — do not add `'unsafe-eval'` or `*` unless a concrete runtime error requires it.
-- CSP is browser-enforced; it does not replace API authorization.
+- Residual: the historical ARN remains in git history after the file change. Rotation/history rewrite is out of scope.
+- Residual: deploy stays broken until the env var is set — that is why we pause merge.
+- Do not put the ARN in `docs/pr-evidence.md`, review comments, or commit messages.
 
 ## Test approach
 
-- Static: template contains `ContentSecurityPolicy` with the directives above; loginproxy apex + wildcard; execute-api ca-central-1; `object-src 'none'`; `frame-ancestors 'none'`; no `ContentSecurityPolicy` Report-Only; HSTS/CORS/CONFIG-004 keys remain; three `!Ref CloudFrontHSTSResponseHeadersPolicy`
-- Update `docs/pr-evidence.md`
-- No Angular tests required
+- Static: prod workflow `DomainCertificateArn=` uses `vars.DOMAIN_CERTIFICATE_ARN`; that override line is not a literal ACM ARN
+- Update `docs/pr-evidence.md` without the identifier
+- No application tests
 
 ## Rollout
 
-- Next SAM deploy. Optional human: `curl -I` for CSP, then login + one API call. Record failures as residual, not a reason to revert CI-proven template structure.
+1. Human: create GitHub Environment `lza-prod` (if missing) and set variable `DOMAIN_CERTIFICATE_ARN` to the existing ACM certificate ARN.
+2. Then merge the implementation PR.
+3. Next tagged prod deploy should pass the parameter from the environment.
 
 ## Approval (checkpoint 2) — **human required**
 

--- a/spec/tasks.md
+++ b/spec/tasks.md
@@ -1,22 +1,22 @@
-# Tasks — CloudFront Content-Security-Policy (CONFIG-002)
+# Tasks — Production certificate environment input (SECRET-001)
 
-Derive from `spec/spec.md` + `features/config-002-cloudfront-csp.feature`. Issue: [#41](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/41).
+Derive from `spec/spec.md` + `features/secret-001-prod-certificate-arn.feature`. Issue: [#46](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/46).
 
-## Milestone 1 — CSP on shared policy (after checkpoint 2 approval)
+## Milestone 1 — Workflow change (after checkpoint 2 approval)
 
-- [ ] **TASK-001** — In `template.yaml` `CloudFrontHSTSResponseHeadersPolicy` `SecurityHeadersConfig`, add `ContentSecurityPolicy` with `Override: true` and the exact policy string from `spec/plan.md` (script `'self'`; style `'self' 'unsafe-inline'`; img/font `'self' data:`; connect `'self'` + loginproxy apex+wildcard + `*.execute-api.ca-central-1.amazonaws.com` + `*.bcparks.ca`; frame-src loginproxy apex+wildcard; form-action `'self'` + loginproxy; `object-src 'none'`; `frame-ancestors 'none'`; `base-uri 'self'`)
-- [ ] **TASK-002** — Keep HSTS, CORS, CONFIG-004 headers (`FrameOptions`, `ContentTypeOptions`, `ReferrerPolicy`, `Permissions-Policy`) and all three `ResponseHeadersPolicyId: !Ref CloudFrontHSTSResponseHeadersPolicy` attachments. Do **not** add a second policy or Report-Only CSP.
-- [ ] **TASK-003** — Update `docs/pr-evidence.md` with static proof of the directives; open **draft** PR linking #41 (`Fixes #41`); do not self-merge
+- [ ] **TASK-001** — In `.github/workflows/lza-deploy-admin-prod.yaml` SAM `--parameter-overrides`, set `DomainCertificateArn=${{ vars.DOMAIN_CERTIFICATE_ARN }}`. Do not change `environment: lza-prod`. Do not touch dev/test workflows.
+- [ ] **TASK-002** — Update `docs/pr-evidence.md` with static proof that the override uses `vars.DOMAIN_CERTIFICATE_ARN` and is not a literal `arn:aws:acm:` value. **Do not reprint the previous ARN.**
+- [ ] **TASK-003** — Open **draft** PR linking #46 (`Fixes #46`). Do **not** self-merge. Leave draft.
 
 ## After checkpoint 2 merge (human)
 
-- [ ] Label #41 `ready-for-agent`
-- [ ] Review; merge (checkpoint 3). Live login/API header smoke is residual — not a merge gate.
+- [ ] Label #46 `ready-for-agent` so Copilot can open the draft (optional; allowed)
+- [ ] **PAUSE before checkpoint 3 merge** until a human creates GitHub Environment `lza-prod` and sets `DOMAIN_CERTIFICATE_ARN`. Comment the blocker on the issue/PR. Then continue the High queue (TEST-001).
 
 ## Completed (prior slices)
 
-- [x] AUTHZ-001 (#6), AUTH-001 (#11), LOG-001 (#19), LOG-003 (#15), LOG-002 (#23), CRYPTO-001 (#27), CONFIG-003 (#32), CONFIG-004 (#36)
+- [x] AUTHZ-001 (#6), AUTH-001 (#11), LOG-001 (#19), LOG-003 (#15), LOG-002 (#23), CRYPTO-001 (#27), CONFIG-003 (#32), CONFIG-004 (#36), CONFIG-002 (#41)
 
 ## Next (not this slice)
 
-- [ ] SECRET-001, TEST-001
+- [ ] TEST-001 token interceptor coverage


### PR DESCRIPTION
## Summary
- Plan + tasks for [#46](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/46) / RA SECRET-001
- Realizes signed `spec/features/secret-001-prod-certificate-arn.feature`
- Implementation may be drafted; **do not merge** until `lza-prod` / `DOMAIN_CERTIFICATE_ARN` exists
- Do not reprint the ARN

## Checkpoint
Checkpoint 2 (plan). After merge, `ready-for-agent` is allowed for a draft impl. CP3 merge stays paused.

Made with [Cursor](https://cursor.com)