### PR TITLE
docs(spec): TEST-001 token interceptor coverage (checkpoint 1)

### DIFF
--- a/spec/features/test-001-token-interceptor.feature
+++ b/spec/features/test-001-token-interceptor.feature
@@ -1,0 +1,45 @@
+Feature: HTTP token interceptor has unit coverage
+  As a developer of the A&R Admin UI
+  I want the session-token HTTP helper covered by tests
+  So that header injection and 403 refresh/retry regressions are caught in CI
+
+  # Finding: RA TEST-001 · Issue: #51
+  # Verification: unit tests in token-interceptor.spec.ts (or equivalent)
+  # Out of scope: AUTH-006 (401 vs 403), AUTH-007 (host allowlist), logout-on-refresh-failure
+
+  Scenario: Bearer token is attached to outbound requests
+    Given a session token is available
+    When an HTTP request is made
+    Then the request includes an Authorization Bearer header with that token
+
+  Scenario: Missing token still sends a Bearer header
+    Given no session token is available
+    When an HTTP request is made
+    Then the request includes an Authorization Bearer header
+    And the interceptor behaviour is otherwise unchanged
+
+  Scenario: Non-forbidden errors pass through
+    Given an HTTP request fails with a status other than 403
+    When the interceptor handles the error
+    Then it does not refresh the session token
+    And the error is propagated
+
+  Scenario: Forbidden response refreshes the token and retries
+    Given an HTTP request fails with 403
+    And token refresh will succeed
+    When the interceptor handles the error
+    Then it refreshes the session token
+    And it retries the request with an Authorization Bearer header
+
+  Scenario: Concurrent forbidden responses share one refresh
+    Given a token refresh is already in progress
+    When another request fails with 403
+    Then the interceptor does not start a second refresh
+    And it retries after the in-flight refresh completes
+
+  Scenario: Refresh failure is propagated
+    Given an HTTP request fails with 403
+    And token refresh will fail
+    When the interceptor handles the error
+    Then the refresh error is propagated
+    And no new logout behaviour is introduced

--- a/spec/features/test-001-token-interceptor.feature
+++ b/spec/features/test-001-token-interceptor.feature
@@ -1,45 +1,36 @@
-Feature: HTTP token interceptor has unit coverage
+Feature: Token interceptor regression coverage
   As a developer of the A&R Admin UI
-  I want the session-token HTTP helper covered by tests
+  I want unit tests for the HTTP token interceptor
   So that header injection and 403 refresh/retry regressions are caught in CI
 
   # Finding: RA TEST-001 · Issue: #51
-  # Verification: unit tests in token-interceptor.spec.ts (or equivalent)
-  # Out of scope: AUTH-006 (401 vs 403), AUTH-007 (host allowlist), logout-on-refresh-failure
+  # Current behaviour only — do not "fix" AUTH-006 (401 vs 403) or AUTH-007 (host allowlist)
 
-  Scenario: Bearer token is attached to outbound requests
-    Given a session token is available
-    When an HTTP request is made
-    Then the request includes an Authorization Bearer header with that token
+  Scenario: Authenticated request receives a Bearer header
+    Given the interceptor has a session token
+    When an HTTP request is sent
+    Then the request includes Authorization Bearer with that token
 
-  Scenario: Missing token still sends a Bearer header
-    Given no session token is available
-    When an HTTP request is made
-    Then the request includes an Authorization Bearer header
-    And the interceptor behaviour is otherwise unchanged
-
-  Scenario: Non-forbidden errors pass through
-    Given an HTTP request fails with a status other than 403
+  Scenario: Non-403 errors pass through
+    Given an HTTP request that fails with a status other than 403
     When the interceptor handles the error
-    Then it does not refresh the session token
-    And the error is propagated
+    Then it does not refresh the token
+    And the error is surfaced to the caller
 
-  Scenario: Forbidden response refreshes the token and retries
-    Given an HTTP request fails with 403
-    And token refresh will succeed
+  Scenario: HTTP 403 refreshes the token and retries
+    Given an HTTP request that fails with 403
     When the interceptor handles the error
     Then it refreshes the session token
     And it retries the request with an Authorization Bearer header
 
-  Scenario: Concurrent forbidden responses share one refresh
+  Scenario: Refresh failure surfaces the error
+    Given an HTTP request that fails with 403
+    And token refresh fails
+    When the interceptor handles the error
+    Then the failure is surfaced
+    And no new logout behaviour is introduced
+
+  Scenario: Concurrent 403s share one in-flight refresh
     Given a token refresh is already in progress
     When another request fails with 403
-    Then the interceptor does not start a second refresh
-    And it retries after the in-flight refresh completes
-
-  Scenario: Refresh failure is propagated
-    Given an HTTP request fails with 403
-    And token refresh will fail
-    When the interceptor handles the error
-    Then the refresh error is propagated
-    And no new logout behaviour is introduced
+    Then a second refresh is not started

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -13,49 +13,49 @@
 
 ### Problem
 
-The HTTP helper that attaches the staff session token to API calls, and retries after a forbidden response by refreshing that token, has no automated tests. A regression in header injection or refresh/retry would ship unnoticed.
+The HTTP interceptor that attaches the staff session token to outbound requests, and that retries after a 403 by refreshing that token, has no automated tests. Regressions in header injection or refresh/retry would ship unnoticed.
 
 ### Outcome
 
-There is a focused unit spec for that helper covering **current** behaviour:
+A focused unit spec covers the **current** interceptor behaviour:
 
-- Requests include an `Authorization: Bearer …` header from the session token (empty Bearer when no token — do not change that here).
-- Errors other than 403 pass through without a refresh.
-- A 403 triggers a token refresh and a retry of the same request with the (possibly new) header.
-- If a refresh is already in flight, later 403s wait for it rather than starting a second refresh.
-- If refresh fails, the error is propagated (no new logout behaviour in this slice).
+1. Authenticated requests get a Bearer token header
+2. Non-403 failures pass through without a refresh
+3. HTTP 403 triggers a token refresh and retries the request
+4. Refresh failure surfaces the error (no new logout path)
+5. Concurrent 403s share one in-flight refresh
+
+This slice does **not** change interceptor production code except as required to make tests compile. AUTH-006 (401 vs 403) and AUTH-007 (host allowlist) stay follow-ups. The assessment’s “omit header when unauthenticated” and “logout on refresh failure” are **not** current behaviour and are out of scope.
 
 ### Users & personas
 
 | Persona | Goal |
 | --- | --- |
 | Developer | Catch interceptor regressions in CI |
-| Security reviewer | Confirm token attachment and 403 retry are locked by tests |
-| Staff user | No behaviour change |
+| Security reviewer | Confirm coverage matches today’s 403-refresh design |
 
 ### Scope
 
 #### In scope (#51)
 
-- New `token-interceptor.spec.ts` (or equivalent) for `TokenInterceptor`
-- Coverage listed under Outcome
-- Tests use the existing Angular HTTP testing utilities; mock Keycloak `getToken` / `refreshToken`
+- `token-interceptor.spec.ts` covering the scenarios above
+- HttpClient testing module (or equivalent Karma/Jasmine HTTP mocks already in the project)
 
 #### Out of scope
 
-- Changing interceptor behaviour (including adding logout on refresh failure)
-- AUTH-006: treat 401 the same as 403
-- AUTH-007: only attach tokens to allowlisted API hosts
-- E2E / live Keycloak
+- Changing 403 to 401 (AUTH-006)
+- Restricting which hosts receive the Bearer header (AUTH-007)
+- Adding logout on refresh failure
+- E2E / live Keycloak tests
 
 ### Journeys
 
-1. Interceptor coverage — see `features/test-001-token-interceptor.feature`
+1. See `features/test-001-token-interceptor.feature`
 
 ### Non-functional requirements
 
-- Tests run in existing `npm run test-ci` / CI Test job
-- No production code change unless a test cannot compile against current API (prefer tests-only)
+- Tests run in existing `yarn test-ci`
+- No production behaviour change
 
 ### Traceability
 
@@ -75,18 +75,12 @@ There is a focused unit spec for that helper covering **current** behaviour:
 
 ---
 
-## Paused slices
-
-### SECRET-001 — Prod certificate environment input
-
-- **Issue:** [#46](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/46) (paused)
-- **Feature:** `features/secret-001-prod-certificate-arn.feature`
-- **Draft impl:** [#50](https://github.com/bcgov/bcparks-ar-admin-agentic/pull/50)
-- **Blocker:** GitHub Environment `lza-prod` / `DOMAIN_CERTIFICATE_ARN` is not configured (API 404). Do not merge until a human sets it.
-
----
-
 ## Completed slices
+
+### SECRET-001 — Prod certificate input
+
+- **Issue:** [#46](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/46) (paused: `lza-prod` / `DOMAIN_CERTIFICATE_ARN` not configured; draft PR open)
+- **Feature:** `features/secret-001-prod-certificate-arn.feature`
 
 ### CONFIG-002 — Content-Security-Policy
 
@@ -95,7 +89,7 @@ There is a focused unit spec for that helper covering **current** behaviour:
 
 ### CONFIG-004 — Browser security headers
 
-- **Issue:** [#36](https://github.com/bcparks-ar-admin-agentic/issues/36) (shipped)
+- **Issue:** [#36](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/36) (shipped)
 - **Feature:** `features/config-004-cloudfront-security-headers.feature`
 
 ### CONFIG-003 — CloudFront HSTS

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -5,59 +5,63 @@
 
 ---
 
-## Active slice — SECRET-001 (prod certificate input)
+## Active slice — TEST-001 (token interceptor coverage)
 
-**Issue:** [#46](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/46)  
-**Finding:** RA SECRET-001  
-**Feature:** `features/secret-001-prod-certificate-arn.feature`
+**Issue:** [#51](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/51)  
+**Finding:** RA TEST-001  
+**Feature:** `features/test-001-token-interceptor.feature`
 
 ### Problem
 
-The production deploy workflow embeds a full ACM certificate identifier (including the production cloud account) in the repository. Anyone who can read the repo can enumerate that account.
+The HTTP helper that attaches the staff session token to API calls, and retries after a forbidden response by refreshing that token, has no automated tests. A regression in header injection or refresh/retry would ship unnoticed.
 
 ### Outcome
 
-The production deploy step reads the certificate identifier from a production environment input (`DOMAIN_CERTIFICATE_ARN`) instead of a literal in the workflow file. Non-production workflows are unchanged. The value itself is not copied into specs, evidence, or review comments.
+There is a focused unit spec for that helper covering **current** behaviour:
 
-**Delivery pause:** do not merge the workflow change until a human has created the `lza-prod` GitHub Environment and set `vars.DOMAIN_CERTIFICATE_ARN`. Merging first would break production deploys.
+- Requests include an `Authorization: Bearer …` header from the session token (empty Bearer when no token — do not change that here).
+- Errors other than 403 pass through without a refresh.
+- A 403 triggers a token refresh and a retry of the same request with the (possibly new) header.
+- If a refresh is already in flight, later 403s wait for it rather than starting a second refresh.
+- If refresh fails, the error is propagated (no new logout behaviour in this slice).
 
 ### Users & personas
 
 | Persona | Goal |
 | --- | --- |
-| Platform operator | Prod deploy still receives a valid certificate identifier |
-| Security reviewer | Confirm the workflow no longer contains a literal ACM ARN |
-| Release manager | Know the environment variable must exist before the change ships |
+| Developer | Catch interceptor regressions in CI |
+| Security reviewer | Confirm token attachment and 403 retry are locked by tests |
+| Staff user | No behaviour change |
 
 ### Scope
 
-#### In scope (#46)
+#### In scope (#51)
 
-- Replace the hardcoded `DomainCertificateArn` on the LZA prod deploy workflow with `${{ vars.DOMAIN_CERTIFICATE_ARN }}`
-- Static proof that the prod workflow no longer contains a literal `arn:aws:acm:` on that parameter
-- Document the `lza-prod` environment prerequisite
+- New `token-interceptor.spec.ts` (or equivalent) for `TokenInterceptor`
+- Coverage listed under Outcome
+- Tests use the existing Angular HTTP testing utilities; mock Keycloak `getToken` / `refreshToken`
 
 #### Out of scope
 
-- Dev/test hardcoded ARNs (SECRET-002)
-- Creating the GitHub Environment or writing the secret/variable (human / org admin)
-- Rotating the certificate
-- Putting the ARN in comments, evidence, or this spec
+- Changing interceptor behaviour (including adding logout on refresh failure)
+- AUTH-006: treat 401 the same as 403
+- AUTH-007: only attach tokens to allowlisted API hosts
+- E2E / live Keycloak
 
 ### Journeys
 
-1. Prod workflow uses environment input — see `features/secret-001-prod-certificate-arn.feature`
+1. Interceptor coverage — see `features/test-001-token-interceptor.feature`
 
 ### Non-functional requirements
 
-- No application code change
-- Evidence must not reprint the ARN
+- Tests run in existing `npm run test-ci` / CI Test job
+- No production code change unless a test cannot compile against current API (prefer tests-only)
 
 ### Traceability
 
 | Finding | Issue | Feature |
 | --- | --- | --- |
-| RA SECRET-001 | #46 | `features/secret-001-prod-certificate-arn.feature` |
+| RA TEST-001 | #51 | `features/test-001-token-interceptor.feature` |
 
 ### Sign-off (checkpoint 1) — **human required**
 
@@ -67,7 +71,18 @@ The production deploy step reads the certificate identifier from a production en
 | Tech lead | | |
 | QA | | |
 
-> Do not add `ready-for-agent` to #46 until this spec PR is merged. Do not merge the implementation PR until `lza-prod` / `DOMAIN_CERTIFICATE_ARN` exists.
+> Do not add `ready-for-agent` to #51 until this spec PR is merged.
+
+---
+
+## Paused slices
+
+### SECRET-001 — Prod certificate environment input
+
+- **Issue:** [#46](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/46) (paused)
+- **Feature:** `features/secret-001-prod-certificate-arn.feature`
+- **Draft impl:** [#50](https://github.com/bcgov/bcparks-ar-admin-agentic/pull/50)
+- **Blocker:** GitHub Environment `lza-prod` / `DOMAIN_CERTIFICATE_ARN` is not configured (API 404). Do not merge until a human sets it.
 
 ---
 
@@ -80,7 +95,7 @@ The production deploy step reads the certificate identifier from a production en
 
 ### CONFIG-004 — Browser security headers
 
-- **Issue:** [#36](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/36) (shipped)
+- **Issue:** [#36](https://github.com/bcparks-ar-admin-agentic/issues/36) (shipped)
 - **Feature:** `features/config-004-cloudfront-security-headers.feature`
 
 ### CONFIG-003 — CloudFront HSTS


### PR DESCRIPTION
## Summary
- Spec + Gherkin for [#51](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/51) / RA TEST-001
- Unit coverage of current TokenInterceptor behaviour
- AUTH-006 (401 vs 403) and AUTH-007 (host allowlist) out of scope
- SECRET-001 remains paused on `lza-prod`

## Checkpoint
Checkpoint 1 (spec). Do not label `ready-for-agent` until plan is signed.

Made with [Cursor](https://cursor.com)