### PR TITLE
docs(spec): AUTHZ-001 admin route guard

### DIFF
--- a/docs/bcparks-ar-admin-rapid-assessment-tickets.md
+++ b/docs/bcparks-ar-admin-rapid-assessment-tickets.md
@@ -18,13 +18,13 @@ Generated: 2026-08-12 · Reset for agentic-b: 2026-08-31 · Raw findings: **55**
 | ID | Severity | Domain | Component | Title | File? | GitHub |
 | --- | --- | --- | --- | --- | --- | --- |
 | AUTH-001 | High | AUTHENTICATION | auth-layer | Keycloak OIDC client initialised with `{}` — PKCE (S256) not config... | yes | pending |
-| AUTHZ-001 | High | AUTHORIZATION | auth-layer | Authorization bypass via URL query parameter injection on admin-onl... | yes | pending |
+| AUTHZ-001 | High | AUTHORIZATION | auth-layer | Authorization bypass via URL query parameter injection on admin-onl... | yes | #55 |
 | CONFIG-002 | High | CONFIGURATION | cloudfront-cdn | Missing Content-Security-Policy Header on All CloudFront Cache Beha... | yes | pending |
 | CONFIG-003 | High | CONFIGURATION | cloudfront-cdn | Missing Strict-Transport-Security (HSTS) Header on All CloudFront C... | yes | pending |
 | CONFIG-004 | High | CONFIGURATION | cloudfront-cdn | Missing X-Frame-Options, X-Content-Type-Options, Referrer-Policy, a... | yes | pending |
-| LOG-001 | High | SECURITY_LOGGING | shared-infrastructure | Full configuration object written to browser console | yes | pending |
+| LOG-001 | High | SECURITY_LOGGING | shared-infrastructure | Full configuration object written to browser console | yes | #56 |
 | LOG-002 | High | SECURITY_LOGGING | auth-layer | Keycloak authentication lifecycle events logged at debug level only | yes | pending |
-| LOG-003 | High | SECURITY_LOGGING | auth-layer | Authorization failures in AuthGuard are never logged | yes | pending |
+| LOG-003 | High | SECURITY_LOGGING | auth-layer | Authorization failures in AuthGuard are never logged | yes | #57 |
 | SECRET-001 | High | SECRETS | cloudfront-cdn | Production AWS Account ID Embedded in ACM Certificate ARN in Prod C... | yes | pending |
 | TEST-001 | High | TESTING | auth-layer | HTTP token interceptor has zero test coverage | yes | pending |
 | AUTH-002 | Medium | AUTHENTICATION | auth-layer | Client-side `JwtUtil.decodeToken()` performs no signature verificat... | yes | pending |

--- a/spec/features/authz-001-admin-route-guard.feature
+++ b/spec/features/authz-001-admin-route-guard.feature
@@ -1,0 +1,43 @@
+Feature: Admin route guard ignores query string and fragment
+  As a security-conscious operator of the A&R Admin UI
+  I want admin-only routes to enforce capabilities on the path
+  So that adding query parameters cannot bypass client-side route protection
+
+  # Finding: RA AUTHZ-001 · Issue: #55
+  # Verification: unit tests in src/app/guards/auth.guard.spec.ts (no live Keycloak required)
+
+  @R-01.1
+  Scenario: Non-admin denied lock-records when query string present
+    Given I am authenticated and authorized for the application
+    And I am not allowed the "lock-records" capability
+    When I activate the route with url "/lock-records?x=1"
+    Then the guard redirects me to "/"
+    And I am not allowed to activate Lock Records
+
+  @R-01.2
+  Scenario: Non-admin denied manage-subareas when query string present
+    Given I am authenticated and authorized for the application
+    And I am not allowed the "manage-subareas" capability
+    When I activate the route with url "/manage-subareas?foo=bar"
+    Then the guard redirects me to "/"
+
+  @R-01.3
+  Scenario: Non-admin denied export-reports when query string present
+    Given I am authenticated and authorized for the application
+    And I am not allowed the "export-reports" capability
+    When I activate the route with url "/export-reports?download=1"
+    Then the guard redirects me to "/"
+
+  @R-01.4
+  Scenario: Admin allowed lock-records when query string present
+    Given I am authenticated and authorized for the application
+    And I am allowed the "lock-records" capability
+    When I activate the route with url "/lock-records?fiscal=2024"
+    Then the guard allows activation
+
+  @R-01.5
+  Scenario: Path without query string still denied for non-admin
+    Given I am authenticated and authorized for the application
+    And I am not allowed the "lock-records" capability
+    When I activate the route with url "/lock-records"
+    Then the guard redirects me to "/"

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1,54 +1,61 @@
-# Spec — {{SERVICE_NAME}}
+# Spec — BC Parks Attendance & Revenue (Admin)
 
 > Technology-free. Describe *what* and *why*, not frameworks or cloud products.
+> Living document: one **active** slice for checkpoint 1; completed slices summarised below.
 
-## Upstream intent
+---
 
-Derived from: `intent/{{slug}}.md` — summarize or link the agreed intent this spec implements.
+## Active slice
 
-## Problem
+### AUTHZ-001 — Admin route guard must ignore query string / fragment
 
-{{Who is stuck, and what pain do they have today?}}
+- **Issue:** [#55](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/55)
+- **Finding:** Rapid assessment `ra-2026-07-21T171227Z` · `AUTHZ-001`
+- **Feature:** `features/authz-001-admin-route-guard.feature`
 
-## Outcome
+#### Problem
 
-{{Measurable outcome for the user / business.}}
+Staff who are authenticated but **not** allowed certain admin capabilities can still open admin-only screens by adding a query string (or fragment) to the URL. The client route guard compares the full URL string to a bare path, so `/lock-records?x=1` fails the equality check and the denial never runs.
 
-## Users & personas
+#### Outcome
+
+Admin-only routes are enforced on the **path** (query and fragment ignored for the capability check). Non-admins are sent home whether or not they append `?…` / `#…`. Admins who hold the capability still reach the screen with query params intact for legitimate filters.
+
+#### Users & personas
 
 | Persona | Goal |
 | --- | --- |
-| {{…}} | {{…}} |
+| Parks staff (non-admin) | Use day-to-day A&R screens without seeing or opening admin-only tools |
+| Parks admin | Open Lock Records / Manage Subareas / Export Reports, including with filters in the query string |
+| Security reviewer | Confirm client-side route protection cannot be bypassed by URL tinkering |
 
-## Scope
+#### Scope
 
-### In scope (this release)
+**In scope**
 
-- {{…}}
+- Fix capability checks for admin-only routes so path matching ignores query string and fragment
+- Cover bypass and allow paths with automated scenarios in `authz-001-admin-route-guard.feature` (unit-level verification)
 
-### Out of scope
+**Out of scope**
 
-- {{…}}
+- Server-side authorization (API must remain authoritative)
+- Changing which roles map to each capability
+- Header nav visibility (separate finding AUTHZ-003)
 
-## Journeys
+#### Open questions
 
-1. {{Happy path name}} — see `features/{{name}}.feature`
-2. {{…}}
+- None blocking — path-only match is the agreed fix shape from the assessment.
 
-## Non-functional requirements
-
-- Accessibility: WCAG 2.1 AA
-- Privacy: {{classification + PIA status}}
-- Availability: {{…}}
-
-## Open questions
-
-- [ ] {{…}}
-
-## Sign-off (checkpoint 1)
+#### Sign-off (checkpoint 1)
 
 | Role | Name | Date |
 | --- | --- | --- |
 | Product / PM | | |
 | BA | | |
 | QA (acceptance ownership) | | |
+
+---
+
+## Completed slices
+
+_None yet._


### PR DESCRIPTION
## Summary
- Checkpoint 1 spec + Gherkin for RA **AUTHZ-001** ([#55](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/55))
- Path-only admin route enforcement; query/fragment must not bypass denial

## Test plan
- [ ] BA/PM simulated checkpoint 1 review
- [ ] Merge only after Conversation receipt APPROVED

Made with [Cursor](https://cursor.com)