### PR TITLE
docs(plan): AUTHZ-001 AuthGuard path matching

### DIFF
--- a/spec/plan.md
+++ b/spec/plan.md
@@ -1,44 +1,60 @@
-# Plan — {{SERVICE_NAME}}
+# Plan — AuthGuard path matching (AUTHZ-001)
 
-> Architecture and delivery approach. Technology belongs here (not in `spec.md`).
+> Architecture and delivery approach for issue #55 / RA AUTHZ-001.
 
 ## Summary
 
-{{How we will realize the spec.}}
+Harden `AuthGuard` so admin-route permission checks use the **path** portion of the requested URL (ignore query string and fragment). Extend existing Karma/Jasmine tests. No dependency or hosting changes. No Design System / OpenShift migration.
 
 ## Architecture
 
 ```text
-{{e.g. Browser → OpenShift Route → Service → API → DB}}
+Browser → AuthGuard.canActivate(route, state)
+        → KeycloakService.isAllowed(capability)
+        → allow component | redirect to "/" or "/unauthorized" | login flow
+
+API authorization remains in bcparks-ar-api (out of scope).
 ```
 
-## Key decisions (ADRs may expand)
+## Key decisions
 
 | Decision | Choice | Rationale |
 | --- | --- | --- |
-| UI | B.C. Design System React | Constitution P2 |
-| Hosting | OpenShift PaaS | Constitution P4 |
-| Auth | {{Entra / …}} | {{…}} |
+| Match strategy | Compare path only (strip `?` / `#` from `state.url`), or equivalent Router URL-tree path | Fixes exact-string bypass; minimal diff |
+| Scope of routes | Same four admin checks already in the guard | Matches finding; avoids unrelated AUTHZ-002 redesign |
+| UI stack | Existing Angular + Parks theme | Constitution J6 |
+| Hosting | Unchanged AWS | Constitution J6 |
+| Verification | Unit tests in `auth.guard.spec.ts` | No Keycloak/API required for CI proof |
 
 ## Security & privacy
 
-- Classification: {{…}}
-- PIA status: {{not started / in progress / complete — link}}
-- Secrets: {{…}}
+- Classification: Internal staff UI
+- PIA: No new data flows
+- Secrets: None
+- Residual risk: Client-side guards are bypassable by a determined user who calls the API directly — API must continue to enforce roles
 
 ## Test approach
 
-- Default integrity tier: **CODEOWNERS on acceptance criteria**
-- Features under `spec/features/` owned by: {{QA lead / path}}
+- Extend `src/app/guards/auth.guard.spec.ts`
+- Scenarios from `spec/features/authz-001-admin-route-guard.feature` (`@R-01.1`–`@R-01.5`)
+- CI: existing **PR Checks** (`yarn lint` / `yarn test-ci`)
+- Append finding block to `docs/pr-evidence.md` on the implementation PR (do not overwrite prior findings)
 
 ## Rollout
 
-- Environments: {{dev / test / prod}}
-- Migration / cutover: {{n/a for greenfield}}
+- Environments: ship with next admin UI deploy (no special cutover)
+- Migration: n/a
+
+## Tasks
+
+1. Add path helper (or inline strip) used by all admin `isAllowed` URL checks in `auth.guard.ts`
+2. Add/extend unit tests covering query-string bypass and admin allow-with-query
+3. Generate/append `docs/pr-evidence.md` for AUTHZ-001 with Review receipt
+4. Confirm PR touches `src/` (not evidence-only)
 
 ## Approval (checkpoint 2)
 
 | Role | Name | Date |
 | --- | --- | --- |
 | Architect / tech lead | | |
-| Security (if required) | | |
+| Security (if required) | Finding is High; fix is local path match — proceed when TL signs | |

--- a/spec/tasks.md
+++ b/spec/tasks.md
@@ -1,12 +1,6 @@
-# Tasks — {{SERVICE_NAME}}
+# Tasks — AUTHZ-001 (active)
 
-Derive from `spec.md` + `features/`. Prefer vertical slices.
-
-## Milestone 1
-
-- [ ] {{TASK-001}} — {{description}} — covers `features/{{…}}.feature` scenarios {{…}}
-- [ ] {{TASK-002}} — …
-
-## Backlog
-
-- [ ] …
+- [ ] Path-only match in `AuthGuard` admin capability checks
+- [ ] Unit tests for `@R-01.1`–`@R-01.5` in `auth.guard.spec.ts`
+- [ ] Append `docs/pr-evidence.md` for AUTHZ-001
+- [ ] Checkpoint 3 review + merge (must change `src/`)


### PR DESCRIPTION
## Summary
- Checkpoint 2 plan + tasks for RA **AUTHZ-001** ([#55](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/55))
- Spec already merged in #58

## Test plan
- [ ] Tech lead simulated checkpoint 2
- [ ] Merge; then label `ready-for-agent` on #55 for cloud Copilot

Made with [Cursor](https://cursor.com)