### PR TITLE
docs(spec): LOG-003 authorization failure logging

### DIFF
--- a/spec/criteria-index.json
+++ b/spec/criteria-index.json
@@ -1,6 +1,36 @@
 {
-  "generatedAt": "2026-09-02T17:13:19.487Z",
+  "generatedAt": "2026-09-02T17:26:31.812Z",
   "criteria": [
+    {
+      "id": "R-01.1",
+      "feature": "spec/features/authz-001-admin-route-guard.feature",
+      "scenario": "Non-admin denied lock-records when query string present",
+      "tier": null
+    },
+    {
+      "id": "R-01.2",
+      "feature": "spec/features/authz-001-admin-route-guard.feature",
+      "scenario": "Non-admin denied manage-subareas when query string present",
+      "tier": null
+    },
+    {
+      "id": "R-01.3",
+      "feature": "spec/features/authz-001-admin-route-guard.feature",
+      "scenario": "Non-admin denied export-reports when query string present",
+      "tier": null
+    },
+    {
+      "id": "R-01.4",
+      "feature": "spec/features/authz-001-admin-route-guard.feature",
+      "scenario": "Admin allowed lock-records when query string present",
+      "tier": null
+    },
+    {
+      "id": "R-01.5",
+      "feature": "spec/features/authz-001-admin-route-guard.feature",
+      "scenario": "Path without query string still denied for non-admin",
+      "tier": null
+    },
     {
       "id": "R-00.1",
       "feature": "spec/features/example-happy-path.feature",
@@ -11,6 +41,36 @@
       "id": "R-00.2",
       "feature": "spec/features/example-happy-path.feature",
       "scenario": "Validation prevents incomplete submission",
+      "tier": null
+    },
+    {
+      "id": "R-02.1",
+      "feature": "spec/features/log-001-no-config-console-dump.feature",
+      "scenario": "Config init does not console.log the configuration object",
+      "tier": null
+    },
+    {
+      "id": "R-03.1",
+      "feature": "spec/features/log-003-authz-failure-logging.feature",
+      "scenario": "Authenticated but unauthorized user denial is logged before redirect",
+      "tier": null
+    },
+    {
+      "id": "R-03.2",
+      "feature": "spec/features/log-003-authz-failure-logging.feature",
+      "scenario": "Capability denial for a protected admin route is logged before redirect",
+      "tier": null
+    },
+    {
+      "id": "R-03.3",
+      "feature": "spec/features/log-003-authz-failure-logging.feature",
+      "scenario": "Capability denial still logs when the URL has a query string",
+      "tier": null
+    },
+    {
+      "id": "R-03.4",
+      "feature": "spec/features/log-003-authz-failure-logging.feature",
+      "scenario": "Allowed activation does not emit an authorization-failure log",
       "tier": null
     }
   ]

--- a/spec/features/log-003-authz-failure-logging.feature
+++ b/spec/features/log-003-authz-failure-logging.feature
@@ -1,0 +1,44 @@
+Feature: Authorization failures in the route guard are logged
+  As a security-conscious operator of the A&R Admin UI
+  I want authorization denials recorded at an appropriate log level
+  So that probing or misconfiguration leaves an auditable trail without leaking tokens
+
+  # Finding: RA LOG-003 · Issue: #57
+  # Verification: unit tests in src/app/guards/auth.guard.spec.ts (no live Keycloak required)
+
+  @R-03.1
+  Scenario: Authenticated but unauthorized user denial is logged before redirect
+    Given I am authenticated
+    And I am not authorized for the application
+    When I activate any protected route
+    Then the guard redirects me to "/unauthorized"
+    And a warn-level authorization-failure log is emitted
+    And the log includes the requested URL or path and a denial reason
+    And the log does not include access tokens, refresh tokens, or raw credentials
+
+  @R-03.2
+  Scenario: Capability denial for a protected admin route is logged before redirect
+    Given I am authenticated and authorized for the application
+    And I am not allowed the "lock-records" capability
+    When I activate the route with url "/lock-records"
+    Then the guard redirects me to "/"
+    And a warn-level authorization-failure log is emitted
+    And the log includes the requested URL or path and a denial reason for the missing capability
+    And the log does not include access tokens, refresh tokens, or raw credentials
+
+  @R-03.3
+  Scenario: Capability denial still logs when the URL has a query string
+    Given I am authenticated and authorized for the application
+    And I am not allowed the "manage-subareas" capability
+    When I activate the route with url "/manage-subareas?x=1"
+    Then the guard redirects me to "/"
+    And a warn-level authorization-failure log is emitted
+    And the log includes enough of the requested URL or path to identify the attempt
+
+  @R-03.4
+  Scenario: Allowed activation does not emit an authorization-failure log
+    Given I am authenticated and authorized for the application
+    And I am allowed the "lock-records" capability
+    When I activate the route with url "/lock-records"
+    Then the guard allows activation
+    And no authorization-failure warn log is emitted for this activation

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -7,42 +7,49 @@
 
 ## Active slice
 
-### LOG-001 — Do not dump full configuration to the browser console
+### LOG-003 — Log authorization failures in the route guard
 
-- **Issue:** [#56](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/56)
-- **Finding:** Rapid assessment `ra-2026-07-21T171227Z` · `LOG-001`
-- **Feature:** `features/log-001-no-config-console-dump.feature`
+- **Issue:** [#57](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/57)
+- **Finding:** Rapid assessment `ra-2026-07-21T171227Z` · `LOG-003`
+- **Feature:** `features/log-003-authz-failure-logging.feature`
 
 #### Problem
 
-On startup the admin UI writes the full runtime configuration object to the browser console. That can expose environment endpoints and other operational detail to anyone with DevTools on a shared or shoulder-surfed workstation.
+When the admin UI denies access (user lacks required roles, or lacks a route-specific capability), the guard redirects without recording any security-relevant log. Probing of authorization boundaries leaves no client-side audit trail.
 
 #### Outcome
 
-The full configuration object is **not** written to `console.log` (or equivalent console dump) during normal config initialization. Staff can still use the app; operators rely on intentional, redacted logging if needed later.
+Every authorization denial in the route guard emits a warn-level (or equivalent security-appropriate) log entry that includes enough context to investigate the attempt (requested path/URL, denial reason, and a non-secret user identifier when available) and **never** includes access tokens, refresh tokens, passwords, or full credential material.
 
 #### Users & personas
 
 | Persona | Goal |
 | --- | --- |
-| Parks staff | Use the app without leaking ops config via the console |
-| Security reviewer | Confirm config dump is gone from the init path |
+| Security / ops reviewer | See authorization denials in logs when investigating abuse or misconfiguration |
+| Parks staff (denied) | Still redirected as today; experience unchanged aside from logging |
+| Implementer | Clear acceptance criteria and tests for log level and redaction |
 
 #### Scope
 
 **In scope**
 
-- Remove or replace the configuration console dump in the config initialization path
-- Automated proof that the dump no longer occurs (unit test)
+- Log before each authorization-failure redirect in the route guard:
+  - authenticated but not authorized for the application (redirect to unauthorized)
+  - authenticated and authorized, but not allowed a protected route capability (redirect away from that route)
+- Structured, security-relevant fields suitable for audit (e.g. event type, outcome, requested URL/path, denial reason, user id and/or email when present, timestamp)
+- Automated tests that document warn-level (or chosen equivalent) behaviour and assert secrets/tokens are not logged
+- Preserve existing redirect destinations and allow/deny decisions (logging only; no authz rule changes)
 
 **Out of scope**
 
-- Broader logging framework redesign (other LOG-* findings)
-- Changing where config is loaded from
+- Server-side / centralized SIEM shipping (other LOG-* findings)
+- Changing authentication flows, login, or logout
+- Changing which roles or capabilities are required
+- Broader logging framework redesign (LOG-004+)
 
 #### Open questions
 
-- None blocking.
+- None blocking. Prefer warn-level via the existing application logger; if log level config would silence warnings in some environments, note that in implementation PR evidence (related: LOG-004) but do not expand scope.
 
 #### Sign-off (checkpoint 1)
 
@@ -51,6 +58,17 @@ The full configuration object is **not** written to `console.log` (or equivalent
 | Product / PM | | |
 | BA | | |
 | QA (acceptance ownership) | | |
+
+---
+
+## In flight
+
+### LOG-001 — Do not dump full configuration to the browser console
+
+- **Issue:** [#56](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/56) (open; Copilot implementation PR in flight — not yet merged/shipped)
+- **Finding:** Rapid assessment `ra-2026-07-21T171227Z` · `LOG-001`
+- **Feature:** `features/log-001-no-config-console-dump.feature`
+- **Note:** Spec/plan for LOG-001 are on `main`; treat as pending ship until #56 is closed. LOG-003 proceeds as the next active rematch slice.
 
 ---
 


### PR DESCRIPTION
## Summary
- Checkpoint 1 spec for RA **LOG-003** ([#57](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/57)): log AuthGuard authorization denials at warn level without leaking tokens
- Active slice set to LOG-003; **AUTHZ-001** remains completed; **LOG-001** (#56) listed under In flight (impl PR open, not shipped)
- Gherkin `@R-03.1`–`@R-03.4` in `spec/features/log-003-authz-failure-logging.feature`; criteria index regenerated

## Test plan
- [ ] Simulated CP1 review (orchestrator)
- [ ] Do not label `ready-for-agent` until CP1 + plan path complete

Closes nothing yet — docs(spec) only.

Made with [Cursor](https://cursor.com)