### PR TITLE
docs(spec): LOG-002 Keycloak lifecycle log levels

### DIFF
--- a/docs/bcparks-ar-admin-rapid-assessment-tickets.md
+++ b/docs/bcparks-ar-admin-rapid-assessment-tickets.md
@@ -26,7 +26,7 @@ Generated: 2026-08-12 · Reset for agentic-b: 2026-08-31 · Raw findings: **55**
 | LOG-002 | High | SECURITY_LOGGING | auth-layer | Keycloak authentication lifecycle events logged at debug level only | yes | #66 |
 | LOG-003 | High | SECURITY_LOGGING | auth-layer | Authorization failures in AuthGuard are never logged | yes | shipped #57 |
 | SECRET-001 | High | SECRETS | cloudfront-cdn | Production AWS Account ID Embedded in ACM Certificate ARN in Prod C... | yes | #67 |
-| TEST-001 | High | TESTING | auth-layer | HTTP token interceptor has zero test coverage | yes | #68 |
+| TEST-001 | High | TESTING | auth-layer | HTTP token interceptor has zero test coverage | yes | shipped #68 |
 | AUTH-002 | Medium | AUTHENTICATION | auth-layer | Client-side `JwtUtil.decodeToken()` performs no signature verificat... | yes | #69 |
 | AUTH-003 | Medium | AUTHENTICATION | auth-layer | No logout mechanism exists; sessions end only on token expiry (risk... | yes | #70 |
 | AUTHZ-002 | Medium | AUTHORIZATION | auth-layer | Dead guard conditions for export-reports and review-data — isAllowe... | yes | #71 |

--- a/spec/features/log-002-keycloak-lifecycle-log-levels.feature
+++ b/spec/features/log-002-keycloak-lifecycle-log-levels.feature
@@ -1,0 +1,39 @@
+Feature: Keycloak lifecycle events logged above debug
+  As a security-conscious operator of the A&R Admin UI
+  I want auth errors, refresh failures, and logout recorded at warn or error
+  So that those events are not silenced when debug logging is off
+
+  # Finding: RA LOG-002 · Issue: #66
+  # Assessment Expected: elevate onAuthError / onAuthRefreshError / onAuthLogout;
+  #   include identity when available; persistent server-side audit endpoint.
+  # This slice implements client-side level + identity. Server-side shipping = LOG-007 residual.
+  # Verification: unit tests on KeycloakService (LoggerService spy); no live IdP required
+
+  @R-05.1
+  Scenario: Auth error is logged at warn or error
+    Given Keycloak JS has been initialised for a real session
+    When the onAuthError callback fires
+    Then a warn- or error-level log records the auth error
+    And the log includes a non-secret identity hint when available
+    And the log does not include access tokens, refresh tokens, or raw credentials
+
+  @R-05.2
+  Scenario: Token refresh error is logged at warn or error
+    Given Keycloak JS has been initialised for a real session
+    When the onAuthRefreshError callback fires
+    Then a warn- or error-level log records the refresh error
+    And the log does not include access tokens, refresh tokens, or raw credentials
+
+  @R-05.3
+  Scenario: Logout is logged at warn or error
+    Given Keycloak JS has been initialised for a real session
+    When the onAuthLogout callback fires
+    Then a warn- or error-level log records the logout
+    And the log does not include access tokens, refresh tokens, or raw credentials
+
+  @R-05.4
+  Scenario: Success lifecycle callbacks may remain below warn
+    Given Keycloak JS has been initialised for a real session
+    When the onAuthSuccess or onAuthRefreshSuccess callback fires
+    Then the callback may continue to use debug-level logging
+    # Assessment called out errors/logout as security-critical; success may stay debug

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -7,54 +7,53 @@
 
 ## Active slice
 
-### TEST-001 — HTTP token interceptor unit coverage
+### LOG-002 — Keycloak authentication lifecycle log levels
 
-- **Issue:** [#68](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/68)
-- **Finding:** Rapid assessment `ra-2026-07-21T171227Z` · `TEST-001`
-- **Feature:** `features/test-001-token-interceptor.feature`
+- **Issue:** [#66](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/66)
+- **Finding:** Rapid assessment `ra-2026-07-21T171227Z` · `LOG-002`
+- **Feature:** `features/log-002-keycloak-lifecycle-log-levels.feature`
 
 #### Problem
 
-The HTTP token interceptor injects Bearer Authorization on outbound requests and handles 403 token-refresh/retry. It has **no** dedicated automated tests. Regressions in header injection, refresh, or retry can ship undetected.
+Keycloak authentication lifecycle callbacks (`onAuthSuccess`, `onAuthError`, `onAuthRefreshSuccess`, `onAuthRefreshError`, `onAuthLogout`) are logged only at **debug**. In realistic deployments (logger default off / above debug), failed authentication, refresh failures, and logout leave no client-side trail. Messages also omit any non-secret identity context.
 
 #### Outcome
 
-A dedicated unit-test suite for the token interceptor covers the assessment Expected behaviours:
+1. `onAuthError`, `onAuthRefreshError`, and `onAuthLogout` emit **warn- or error-level** logs (not debug).
+2. Those logs include a **non-secret identity hint** when available (e.g. user id and/or email from token claims — never access/refresh tokens or passwords).
+3. Automated tests document the chosen levels and redaction.
+4. Assessment also Expected a **persistent server-side audit endpoint** to receive these events — that remains **residual** (tracked under LOG-007); this slice does not invent a new backend.
 
-1. Bearer header is injected on authenticated requests (non-empty token).
-2. When unauthenticated, the request does **not** carry a usable Bearer token value (assessment preferred: header absent; see Open questions for current empty-`Bearer ` behaviour).
-3. HTTP 403 triggers token refresh and request retry with an Authorization header.
-4. Refresh failure is observable to the caller; assessment also Expected logout on refresh failure — **residual** until a logout mechanism exists (AUTH-003 / AUTH-004); this slice must not invent logout.
-
-Tests run in CI with Angular HTTP testing utilities (no live IdP). Production interceptor logic is unchanged except if a tiny fix is required for tests to compile against the public API.
+Success callbacks (`onAuthSuccess` / `onAuthRefreshSuccess`) may remain at debug.
 
 #### Users & personas
 
 | Persona | Goal |
 | --- | --- |
-| Developer / reviewer | Catch interceptor regressions in CI |
-| Security reviewer | Evidence that auth-header and 403 refresh paths are covered |
-| Parks staff | No user-visible change from this slice |
+| Security / ops reviewer | See auth failures and logout in client logs when debug is off |
+| Parks staff | No user-visible change |
+| Implementer | Clear levels + identity rules; no token leakage |
 
 #### Scope
 
 **In scope**
 
-- New `token-interceptor` unit tests covering `@R-04.1`–`@R-04.6`
-- Document residual gaps vs assessment Expected (2) header-absent ideal and (4) logout-on-refresh-failure
-- Append `docs/pr-evidence.md` for TEST-001
+- Raise log level for `onAuthError`, `onAuthRefreshError`, `onAuthLogout` in the Keycloak service
+- Include non-secret identity when available (reuse existing identity helper if present)
+- Unit tests for `@R-05.1`–`@R-05.4`
+- Append `docs/pr-evidence.md` for LOG-002; must change `src/`
 
 **Out of scope**
 
-- Changing 403 → 401 refresh trigger (AUTH-006)
-- Host allowlist for Bearer injection (AUTH-007)
-- Implementing logout or login redirect on refresh failure (AUTH-003 / AUTH-004)
-- Broader HTTP client / API service test suites (other TEST-* findings)
+- Server-side / SIEM shipping or new audit HTTP endpoint (LOG-007)
+- Changing LoggerService default level (LOG-004)
+- AuthGuard denial logging (LOG-003 — shipped)
+- Implementing logout UX (AUTH-003)
 
 #### Open questions
 
-- **Expected (2) — header absent vs empty Bearer:** Current interceptor always sets `Authorization: Bearer ` + token-or-empty. Assessment Expected prefers the header absent when unauthenticated. **Decision for this slice:** tests assert there is no *usable* non-empty Bearer token; do not change production header omission here (may revisit with AUTH-007).
-- **Expected (4) — logout on refresh failure:** No logout API exists yet (AUTH-003). **Decision for this slice:** tests assert the refresh error is surfaced and that this PR does not add logout; document assessment Expected (4) as residual in evidence.
+- **Server-side audit endpoint:** Assessment Expected includes persistent server-side shipping. **Decision for this slice:** client-side warn/error + identity only; document LOG-007 residual in evidence (do not silently drop — call it residual).
+- **Warn vs error:** Prefer `warn` for expected logout and `error`/`warn` for auth/refresh failures; implementer may use warn for all three if simpler — tests accept warn or error.
 
 #### Sign-off (checkpoint 1)
 
@@ -68,16 +67,19 @@ Tests run in CI with Angular HTTP testing utilities (no live IdP). Production in
 
 ## Completed slices (recent)
 
+### TEST-001 — HTTP token interceptor unit coverage
+
+- **Issue:** [#68](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/68) (shipped)
+- **Feature:** `features/test-001-token-interceptor.feature`
+
 ### LOG-003 — Log authorization failures in the route guard
 
 - **Issue:** [#57](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/57) (shipped)
-- **Finding:** Rapid assessment `ra-2026-07-21T171227Z` · `LOG-003`
 - **Feature:** `features/log-003-authz-failure-logging.feature`
 
 ### LOG-001 — Do not dump full configuration to the browser console
 
 - **Issue:** [#56](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/56) (shipped)
-- **Finding:** Rapid assessment `ra-2026-07-21T171227Z` · `LOG-001`
 - **Feature:** `features/log-001-no-config-console-dump.feature`
 
 ---


### PR DESCRIPTION
## Summary
- Active slice for [RA LOG-002](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/66)
- Feature `log-002-keycloak-lifecycle-log-levels.feature` (`@R-05.1`–`@R-05.4`)
- Server-side audit endpoint explicitly residual → LOG-007 (not silently dropped)
- Marks TEST-001 shipped in backlog index

## Test plan
- [ ] CP1 (Alex Rivera) Conversation comment
- [ ] Squash merge

Made with [Cursor](https://cursor.com)