### PR TITLE
docs(spec): CONFIG-004 browser security headers

### DIFF
--- a/spec/features/config-004-cloudfront-security-headers.feature
+++ b/spec/features/config-004-cloudfront-security-headers.feature
@@ -1,0 +1,22 @@
+Feature: Browser security headers on CloudFront responses
+  As a security-conscious operator of the A&R Admin UI
+  I want baseline browser protections on every response
+  So that framing, MIME sniffing, referrer leakage, and unused capabilities are constrained
+
+  # Finding: RA CONFIG-004 · Issue: #104
+  # Assessment: add X-Frame-Options, X-Content-Type-Options: nosniff, Referrer-Policy,
+  # and Permissions-Policy on all cache behaviours (custom policy; not managed SimpleCORS alone).
+  # Scope this slice: those four headers on the existing custom response headers policy.
+  # Do not add or change CSP here (CONFIG-002). Keep HSTS + CORS from CONFIG-003.
+  # Verification: static inspection of template.yaml; live headers residual smoke
+
+  @R-08.1
+  Scenario: Shared policy contains baseline browser protections
+    Given all three cache behaviours reference the shared response headers policy
+    When that policy is inspected
+    Then frame options deny framing (X-Frame-Options DENY)
+    And content type options enable nosniff
+    And referrer policy is strict-origin-when-cross-origin
+    And permissions policy disables unused browser capabilities
+    And HSTS and CORS remain configured
+    And Content-Security-Policy is not required by this slice

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -7,45 +7,53 @@
 
 ## Active slice
 
-### CONFIG-003 — CloudFront HSTS on all cache behaviours
+### CONFIG-004 — Browser security headers (frame / MIME / referrer / permissions)
 
-- **Issue:** [#64](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/64)
-- **Finding:** Rapid assessment `ra-2026-07-21T171227Z` · `CONFIG-003`
-- **Feature:** `features/config-003-cloudfront-hsts.feature`
+- **Issue:** [#104](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/104)
+- **Finding:** Rapid assessment `ra-2026-07-21T171227Z` · `CONFIG-004`
+- **Feature:** `features/config-004-cloudfront-security-headers.feature`
 
 #### Problem
 
-None of the CloudFront cache behaviours emit `Strict-Transport-Security`. HTTPS redirects alone do not give browsers a durable HTTPS requirement, leaving first-contact / cache-expiry SSL-stripping risk and blocking HSTS preload readiness.
+CloudFront responses lack baseline browser protections: no X-Frame-Options (clickjacking risk for authenticated admin UI), no X-Content-Type-Options: nosniff (MIME confusion on static assets), no Referrer-Policy (origin URL leakage to third parties), and no Permissions-Policy (unused browser capabilities unrestricted). The finding originally noted managed SimpleCORS alone; CONFIG-003 already replaced that with a custom HSTS+CORS policy — this slice extends that same custom policy.
 
 #### Outcome
 
-A custom CloudFront response headers policy sets **HSTS** (`max-age` ≥ 31536000, `includeSubDomains`) and is attached to **all three** cache behaviours. CORS behaviour equivalent to the previous managed SimpleCORS policy is preserved. Other security headers (CSP, XFO, Referrer-Policy, Permissions-Policy) remain for CONFIG-002 / CONFIG-004.
+The shared custom response headers policy, attached to **all three** cache behaviours, sets:
+
+1. **X-Frame-Options:** DENY (no framing)
+2. **X-Content-Type-Options:** nosniff
+3. **Referrer-Policy:** strict-origin-when-cross-origin
+4. **Permissions-Policy:** disables unused capabilities (at minimum camera, microphone, geolocation, payment, usb, interest-cohort)
+
+HSTS and CORS from CONFIG-003 remain. Content-Security-Policy remains for CONFIG-002 (not silently narrowed here — CSP is a separate finding).
 
 #### Users & personas
 
 | Persona | Goal |
 | --- | --- |
-| Security reviewer | Confirm HSTS on every behaviour |
-| Parks staff | Modern browsers remember HTTPS |
+| Security reviewer | Confirm four headers on every behaviour |
+| Parks staff | Admin UI not framable / MIME-sniffable |
 | Implementer | Template-only change + evidence |
 
 #### Scope
 
 **In scope**
 
-- Custom `AWS::CloudFront::ResponseHeadersPolicy` with HSTS (+ CORS parity with SimpleCORS)
-- Wire all three cache behaviours to that policy (replace managed SimpleCORS id)
+- Extend existing custom `AWS::CloudFront::ResponseHeadersPolicy` with FrameOptions, ContentTypeOptions, ReferrerPolicy, and Permissions-Policy (custom header if not a native SecurityHeadersConfig property)
+- Keep all three behaviours on that policy
 - Evidence append; must change `template.yaml`
 
 **Out of scope**
 
-- CSP (CONFIG-002), XFO / nosniff / Referrer / Permissions-Policy (CONFIG-004)
-- HSTS preload list submission (ops residual)
-- Live header smoke (residual after deploy)
+- Content-Security-Policy (CONFIG-002)
+- Changing HSTS max-age / preload or CORS parity from CONFIG-003 beyond preserving them
+- Live header smoke after deploy (residual)
+- Submitting HSTS preload list (ops residual)
 
 #### Open questions
 
-- **Preload directive:** Assessment mentions preload list readiness. CloudFront `StrictTransportSecurity` may support `Preload`. Prefer enabling preload when the property exists; if not available in the resource schema used here, document residual and still ship max-age + includeSubDomains.
+- **Permissions-Policy value:** Prefer a restrictive deny-list for unused capabilities (camera, microphone, geolocation, payment, usb, interest-cohort). If CloudFront schema requires CustomHeadersConfig for Permissions-Policy, that is acceptable. Document the exact value in evidence.
 
 #### Sign-off (checkpoint 1)
 
@@ -58,6 +66,11 @@ A custom CloudFront response headers policy sets **HSTS** (`max-age` ≥ 3153600
 ---
 
 ## Completed slices (recent)
+
+### CONFIG-003 — CloudFront HSTS on all cache behaviours
+
+- **Issue:** [#64](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/64) (shipped)
+- **Feature:** `features/config-003-cloudfront-hsts.feature`
 
 ### CRYPTO-001 — CloudFront viewer TLS minimum (TLS 1.2+)
 
@@ -77,12 +90,3 @@ A custom CloudFront response headers policy sets **HSTS** (`max-age` ≥ 3153600
 ### LOG-003 / LOG-001 / AUTHZ-001
 
 - Shipped — see prior rematch rows
-
----
-
-## Completed slices
-
-### AUTHZ-001 — Admin route guard path matching
-
-- **Issue:** [#55](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/55) (shipped)
-- **Feature:** `features/authz-001-admin-route-guard.feature`


### PR DESCRIPTION
## Summary

- Active slice: CONFIG-004 (#104) — X-Frame-Options DENY, X-Content-Type-Options nosniff, Referrer-Policy strict-origin-when-cross-origin, Permissions-Policy deny unused capabilities on the shared CloudFront response headers policy (all three behaviours).
- Feature: `spec/features/config-004-cloudfront-security-headers.feature` (`@R-08.1`).
- Expected preserved: no silent narrowing; CSP stays CONFIG-002; HSTS/CORS from CONFIG-003 preserved.

## Test plan

- [ ] Checkpoint 1 review (Alex Rivera)
- [ ] Merge after Conversation comment approve


Made with [Cursor](https://cursor.com)