### PR TITLE
docs(spec): CONFIG-002 CloudFront CSP

### DIFF
--- a/spec/features/config-002-cloudfront-csp.feature
+++ b/spec/features/config-002-cloudfront-csp.feature
@@ -1,0 +1,19 @@
+Feature: Content-Security-Policy on CloudFront responses
+  As a security-conscious operator of the A&R Admin UI
+  I want browsers to only load scripts and connections we allow
+  So that injected script and unexpected third-party hosts are blocked
+
+  # Finding: RA CONFIG-002 · Issue: #63
+  # Assessment: CSP on all cache behaviours; allowlist loginproxy; no silent narrowing.
+  # Scope: ContentSecurityPolicy on the shared custom response headers policy.
+  # Preserve HSTS, CORS, and CONFIG-004 browser headers. Verification: static template; live smoke residual.
+
+  @R-09.1
+  Scenario: Shared policy contains a sourced Content-Security-Policy
+    Given all three cache behaviours reference the shared response headers policy
+    When that policy is inspected
+    Then it sets Content-Security-Policy
+    And script sources are limited to the same origin
+    And connect and frame sources allow loginproxy and the attendance API hosts
+    And object sources are none and frame ancestors are none
+    And HSTS, CORS, and CONFIG-004 browser headers remain configured

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -7,53 +7,51 @@
 
 ## Active slice
 
-### CONFIG-004 — Browser security headers (frame / MIME / referrer / permissions)
+### CONFIG-002 — Content-Security-Policy on CloudFront responses
 
-- **Issue:** [#104](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/104)
-- **Finding:** Rapid assessment `ra-2026-07-21T171227Z` · `CONFIG-004`
-- **Feature:** `features/config-004-cloudfront-security-headers.feature`
+- **Issue:** [#63](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/63)
+- **Finding:** Rapid assessment `ra-2026-07-21T171227Z` · `CONFIG-002`
+- **Feature:** `features/config-002-cloudfront-csp.feature`
 
 #### Problem
 
-CloudFront responses lack baseline browser protections: no X-Frame-Options (clickjacking risk for authenticated admin UI), no X-Content-Type-Options: nosniff (MIME confusion on static assets), no Referrer-Policy (origin URL leakage to third parties), and no Permissions-Policy (unused browser capabilities unrestricted). The finding originally noted managed SimpleCORS alone; CONFIG-003 already replaced that with a custom HSTS+CORS policy — this slice extends that same custom policy.
+No Content-Security-Policy is emitted on CloudFront responses, and `src/index.html` has no CSP meta fallback. Without CSP the browser cannot restrict script sources, object sources, or frame ancestors. The SPA authenticates via loginproxy.gov.bc.ca (Keycloak) and calls attendance API hosts — those must be allowlisted for connect/frame without opening script execution to arbitrary origins.
 
 #### Outcome
 
-The shared custom response headers policy, attached to **all three** cache behaviours, sets:
+The shared custom response headers policy (all three cache behaviours) sets a **sourced Content-Security-Policy** that at minimum:
 
-1. **X-Frame-Options:** DENY (no framing)
-2. **X-Content-Type-Options:** nosniff
-3. **Referrer-Policy:** strict-origin-when-cross-origin
-4. **Permissions-Policy:** disables unused capabilities (at minimum camera, microphone, geolocation, payment, usb, interest-cohort)
-
-HSTS and CORS from CONFIG-003 remain. Content-Security-Policy remains for CONFIG-002 (not silently narrowed here — CSP is a separate finding).
+1. Limits **script-src** to same origin (`'self'`) — Keycloak JS is bundled from the app origin
+2. Allows **connect-src** / **frame-src** (and form-action as needed) for loginproxy and attendance/API hosts used by the app
+3. Sets **object-src 'none'** and **frame-ancestors 'none'**
+4. Preserves HSTS, CORS, and CONFIG-004 browser headers (XFO / nosniff / Referrer / Permissions-Policy)
 
 #### Users & personas
 
 | Persona | Goal |
 | --- | --- |
-| Security reviewer | Confirm four headers on every behaviour |
-| Parks staff | Admin UI not framable / MIME-sniffable |
+| Security reviewer | Confirm CSP on every behaviour with loginproxy allowlisted |
+| Parks staff | Login and API calls still work under CSP |
 | Implementer | Template-only change + evidence |
 
 #### Scope
 
 **In scope**
 
-- Extend existing custom `AWS::CloudFront::ResponseHeadersPolicy` with FrameOptions, ContentTypeOptions, ReferrerPolicy, and Permissions-Policy (custom header if not a native SecurityHeadersConfig property)
+- Add `ContentSecurityPolicy` to existing `CloudFrontResponseHeadersPolicy` in `template.yaml`
 - Keep all three behaviours on that policy
 - Evidence append; must change `template.yaml`
 
 **Out of scope**
 
-- Content-Security-Policy (CONFIG-002)
-- Changing HSTS max-age / preload or CORS parity from CONFIG-003 beyond preserving them
-- Live header smoke after deploy (residual)
-- Submitting HSTS preload list (ops residual)
+- Adding a CSP `<meta>` tag in `index.html` if the response header covers all behaviours (header is preferred; meta only if needed as residual)
+- Changing HSTS / CORS / CONFIG-004 headers beyond preserving them
+- Live login/API smoke after deploy (residual)
 
 #### Open questions
 
-- **Permissions-Policy value:** Prefer a restrictive deny-list for unused capabilities (camera, microphone, geolocation, payment, usb, interest-cohort). If CloudFront schema requires CustomHeadersConfig for Permissions-Policy, that is acceptable. Document the exact value in evidence.
+- **style-src 'unsafe-inline':** Angular/Bootstrap may require it for this brownfield app — acceptable if documented in evidence; prefer `'self'` plus `'unsafe-inline'` over wide-open style sources.
+- **Exact host patterns:** Prefer `loginproxy.gov.bc.ca` / `*.loginproxy.gov.bc.ca`, `*.execute-api.ca-central-1.amazonaws.com`, `*.bcparks.ca` to match production IdP and API shapes.
 
 #### Sign-off (checkpoint 1)
 
@@ -67,26 +65,16 @@ HSTS and CORS from CONFIG-003 remain. Content-Security-Policy remains for CONFIG
 
 ## Completed slices (recent)
 
+### CONFIG-004 — Browser security headers (frame / MIME / referrer / permissions)
+
+- **Issue:** [#104](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/104) (shipped)
+- **Feature:** `features/config-004-cloudfront-security-headers.feature`
+
 ### CONFIG-003 — CloudFront HSTS on all cache behaviours
 
 - **Issue:** [#64](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/64) (shipped)
 - **Feature:** `features/config-003-cloudfront-hsts.feature`
 
-### CRYPTO-001 — CloudFront viewer TLS minimum (TLS 1.2+)
+### CRYPTO-001 / LOG-002 / TEST-001 / LOG-003 / LOG-001 / AUTHZ-001
 
-- **Issue:** [#74](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/74) (shipped)
-- **Feature:** `features/crypto-001-cloudfront-tls-minimum.feature`
-
-### LOG-002 — Keycloak authentication lifecycle log levels
-
-- **Issue:** [#66](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/66) (shipped)
-- **Feature:** `features/log-002-keycloak-lifecycle-log-levels.feature`
-
-### TEST-001 — HTTP token interceptor unit coverage
-
-- **Issue:** [#68](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/68) (shipped)
-- **Feature:** `features/test-001-token-interceptor.feature`
-
-### LOG-003 / LOG-001 / AUTHZ-001
-
-- Shipped — see prior rematch rows
+- Shipped — see rematch wiki


### PR DESCRIPTION
## Summary

- Active slice: CONFIG-002 (#63) — Content-Security-Policy on shared CloudFront response headers policy (all three behaviours).
- Feature: `spec/features/config-002-cloudfront-csp.feature` (`@R-09.1`).
- Expected preserved: loginproxy + API allowlists; HSTS/CORS/CONFIG-004 headers kept; no silent narrowing.

## Test plan

- [ ] Checkpoint 1 (Alex Rivera) → squash merge

Made with [Cursor](https://cursor.com)