### PR TITLE
docs(plan): CONFIG-002 CloudFront CSP

### DIFF
--- a/spec/plan.md
+++ b/spec/plan.md
@@ -1,44 +1,46 @@
-# Plan — Browser security headers (CONFIG-004)
+# Plan — Content-Security-Policy (CONFIG-002)
 
-> Architecture and delivery for issue [#104](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/104) / RA CONFIG-004.  
+> Architecture and delivery for issue [#63](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/63) / RA CONFIG-002.  
 > Checkpoint 1 (spec) is merged. This document is **checkpoint 2**.
 
 ## Summary
 
-Extend the existing custom `AWS::CloudFront::ResponseHeadersPolicy` (`CloudFrontResponseHeadersPolicy`) so it also sets **X-Frame-Options DENY**, **X-Content-Type-Options nosniff**, **Referrer-Policy strict-origin-when-cross-origin**, and a restrictive **Permissions-Policy**. Keep all three cache behaviours on that policy. Preserve HSTS + CORS from CONFIG-003. Do **not** add CSP (CONFIG-002). Must change `template.yaml`.
+Add `ContentSecurityPolicy` to the existing custom `CloudFrontResponseHeadersPolicy`. Keep all three cache behaviours on that policy. Preserve HSTS, CORS, and CONFIG-004 headers. Must change `template.yaml`.
 
 ## Architecture
 
 ```text
 CloudFrontResponseHeadersPolicy
   SecurityHeadersConfig
-    StrictTransportSecurity (keep)
-    FrameOptions: DENY
-    ContentTypeOptions: Override true (nosniff)
-    ReferrerPolicy: strict-origin-when-cross-origin
-  CustomHeadersConfig (Permissions-Policy)
-    camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()
-  CorsConfig (keep SimpleCORS parity)
-CloudFrontDistribution cache behaviours ×3
-  ResponseHeadersPolicyId: !Ref CloudFrontResponseHeadersPolicy (unchanged wiring)
+    ContentSecurityPolicy: (sourced policy string)
+      default-src 'self'
+      script-src 'self'
+      style-src 'self' 'unsafe-inline'   # brownfield Angular/Bootstrap
+      img-src 'self' data:; font-src 'self' data:
+      connect-src 'self' loginproxy + API hosts
+      frame-src / form-action: loginproxy
+      object-src 'none'; frame-ancestors 'none'; base-uri 'self'
+    (+ existing HSTS / XFO / nosniff / Referrer)
+  CustomHeadersConfig Permissions-Policy (keep)
+  CorsConfig (keep)
 ```
 
 ## Key decisions
 
 | Decision | Choice | Rationale |
 | --- | --- | --- |
-| Scope | Four headers only | Matches assessment; CSP is CONFIG-002 |
-| Frame options | DENY | Strongest clickjacking control for admin UI |
-| Referrer | strict-origin-when-cross-origin | Common gov default; reduces leakage |
-| Permissions-Policy | CustomHeadersConfig deny-list | Not a native SecurityHeadersConfig property on CloudFront |
-| Evidence | `--append --finding CONFIG-004` | Preserve prior receipts |
+| Delivery | Response header on shared policy | Covers all behaviours; preferred over meta-only |
+| script-src | `'self'` | keycloak-js bundled via angular.json |
+| IdP / API | loginproxy + execute-api + bcparks hosts | Matches assessment allowlist need |
+| style-src | include `'unsafe-inline'` | Brownfield Angular/Bootstrap; document in evidence |
+| Evidence | append CONFIG-002 | Preserve receipts |
 
 ## Tasks
 
-1. Extend `CloudFrontResponseHeadersPolicy` in `template.yaml` with FrameOptions, ContentTypeOptions, ReferrerPolicy, Permissions-Policy; keep HSTS/CORS
-2. Confirm all three behaviours still `!Ref` the policy
-3. Append `docs/pr-evidence.md` for CONFIG-004
-4. Checkpoint 3 + merge (must change `template.yaml`; refuse evidence-only)
+1. Add ContentSecurityPolicy to `template.yaml` policy; preserve other headers
+2. Confirm three behaviours still `!Ref` the policy
+3. Append `docs/pr-evidence.md`
+4. Checkpoint 3 + merge (must change `template.yaml`)
 
 ## Approval (checkpoint 2)
 

--- a/spec/tasks.md
+++ b/spec/tasks.md
@@ -1,6 +1,6 @@
-# Tasks — CONFIG-004 (active)
+# Tasks — CONFIG-002 (active)
 
-- [x] Extend `CloudFrontResponseHeadersPolicy` in `template.yaml`: FrameOptions DENY, ContentTypeOptions nosniff, ReferrerPolicy strict-origin-when-cross-origin, Permissions-Policy via CustomHeadersConfig (camera/microphone/geolocation/payment/usb/interest-cohort disabled); preserve HSTS + CORS
-- [x] Confirm all three cache behaviours still reference `!Ref CloudFrontResponseHeadersPolicy`
-- [x] Append `docs/pr-evidence.md` for CONFIG-004 (do not overwrite prior slices)
+- [ ] Add `ContentSecurityPolicy` to `CloudFrontResponseHeadersPolicy` in `template.yaml` (script-src 'self'; connect/frame allow loginproxy + attendance/API hosts; object-src none; frame-ancestors none; style-src may include 'unsafe-inline' for brownfield); preserve HSTS, CORS, CONFIG-004 headers
+- [ ] Confirm all three cache behaviours still reference `!Ref CloudFrontResponseHeadersPolicy`
+- [ ] Append `docs/pr-evidence.md` for CONFIG-002 (do not overwrite prior slices)
 - [ ] Checkpoint 3 + merge (must change `template.yaml`; refuse evidence-only)


### PR DESCRIPTION
## Summary

- Plan + tasks for CONFIG-002 (#63) in one commit.
- Add CSP to shared CloudFront response headers policy; preserve HSTS/CORS/CONFIG-004.

## Test plan

- [ ] Checkpoint 2 (Jordan Lee) → merge → ready-for-agent

Made with [Cursor](https://cursor.com)