### PR TITLE
docs(plan): AUTH-001 Keycloak PKCE S256

### DIFF
--- a/spec/plan.md
+++ b/spec/plan.md
@@ -1,46 +1,38 @@
-# Plan — Content-Security-Policy (CONFIG-002)
+# Plan — Keycloak PKCE S256 (AUTH-001)
 
-> Architecture and delivery for issue [#63](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/63) / RA CONFIG-002.  
+> Architecture and delivery for issue [#62](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/62) / RA AUTH-001.  
 > Checkpoint 1 (spec) is merged. This document is **checkpoint 2**.
 
 ## Summary
 
-Add `ContentSecurityPolicy` to the existing custom `CloudFrontResponseHeadersPolicy`. Keep all three cache behaviours on that policy. Preserve HSTS, CORS, and CONFIG-004 headers. Must change `template.yaml`.
+Change Keycloak adapter `init({})` to `init({ pkceMethod: 'S256' })` in `src/app/services/keycloak.service.ts`. Add unit coverage asserting init options. Must change `src/` (refuse evidence-only). Append evidence.
 
 ## Architecture
 
 ```text
-CloudFrontResponseHeadersPolicy
-  SecurityHeadersConfig
-    ContentSecurityPolicy: (sourced policy string)
-      default-src 'self'
-      script-src 'self'
-      style-src 'self' 'unsafe-inline'   # brownfield Angular/Bootstrap
-      img-src 'self' data:; font-src 'self' data:
-      connect-src 'self' loginproxy + API hosts
-      frame-src / form-action: loginproxy
-      object-src 'none'; frame-ancestors 'none'; base-uri 'self'
-    (+ existing HSTS / XFO / nosniff / Referrer)
-  CustomHeadersConfig Permissions-Policy (keep)
-  CorsConfig (keep)
+KeycloakService.init()
+  when KEYCLOAK_ENABLED:
+    new Keycloak(config)
+    keycloakAuth.init({ pkceMethod: 'S256' })  // was {}
+keycloak.service.spec.ts
+  asserts init called with pkceMethod S256
 ```
 
 ## Key decisions
 
 | Decision | Choice | Rationale |
 | --- | --- | --- |
-| Delivery | Response header on shared policy | Covers all behaviours; preferred over meta-only |
-| script-src | `'self'` | keycloak-js bundled via angular.json |
-| IdP / API | loginproxy + execute-api + bcparks hosts | Matches assessment allowlist need |
-| style-src | include `'unsafe-inline'` | Brownfield Angular/Bootstrap; document in evidence |
-| Evidence | append CONFIG-002 | Preserve receipts |
+| API | `pkceMethod: 'S256'` on init | keycloak-js v25; matches assessment |
+| Tests | Unit spy on init | No live IdP in CI |
+| Mock auth | Do not invent full localMockAuth | Out of AUTH-001 scope; constitution residual |
+| Evidence | append AUTH-001 | Preserve receipts |
 
 ## Tasks
 
-1. Add ContentSecurityPolicy to `template.yaml` policy; preserve other headers
-2. Confirm three behaviours still `!Ref` the policy
+1. Update `keycloak.service.ts` init options to include PKCE S256
+2. Add/update unit test(s) for init options
 3. Append `docs/pr-evidence.md`
-4. Checkpoint 3 + merge (must change `template.yaml`)
+4. Checkpoint 3 + merge (must change `src/`)
 
 ## Approval (checkpoint 2)
 

--- a/spec/tasks.md
+++ b/spec/tasks.md
@@ -1,6 +1,6 @@
-# Tasks — CONFIG-002 (active)
+# Tasks — AUTH-001 (active)
 
-- [x] Add `ContentSecurityPolicy` to `CloudFrontResponseHeadersPolicy` in `template.yaml` (script-src 'self'; connect/frame allow loginproxy + attendance/API hosts; object-src none; frame-ancestors none; style-src may include 'unsafe-inline' for brownfield); preserve HSTS, CORS, CONFIG-004 headers
-- [x] Confirm all three cache behaviours still reference `!Ref CloudFrontResponseHeadersPolicy`
-- [x] Append `docs/pr-evidence.md` for CONFIG-002 (do not overwrite prior slices)
-- [ ] Checkpoint 3 + merge (must change `template.yaml`; refuse evidence-only)
+- [ ] Update `src/app/services/keycloak.service.ts` so Keycloak `init` uses `pkceMethod: 'S256'` (not `{}`)
+- [ ] Add or update unit test(s) in `src/app/services/keycloak.service.spec.ts` asserting init options include PKCE S256
+- [ ] Append `docs/pr-evidence.md` for AUTH-001 (do not overwrite prior slices)
+- [ ] Checkpoint 3 + merge (must change `src/`; refuse evidence-only)


### PR DESCRIPTION
## Summary

- Plan + tasks for AUTH-001 (#62) in one commit.
- `init({ pkceMethod: 'S256' })` + unit tests; must change `src/`.

## Test plan

- [ ] Checkpoint 2 (Jordan Lee) → merge → ready-for-agent

Made with [Cursor](https://cursor.com)