### PR TITLE
docs(plan): AUTH-002 token claims from Keycloak

### DIFF
--- a/spec/plan.md
+++ b/spec/plan.md
@@ -1,35 +1,35 @@
-# Plan — Prod certificate ARN from vars (SECRET-001)
+# Plan — Token claims from Keycloak session (AUTH-002)
 
-> Architecture and delivery for issue [#67](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/67) / RA SECRET-001.  
+> Architecture and delivery for issue [#69](https://github.com/bcgov/bcparks-ar-admin-agentic/issues/69) / RA AUTH-002.  
 > Checkpoint 1 (spec) is merged. This document is **checkpoint 2**.
 
 ## Summary
 
-In `.github/workflows/lza-deploy-admin-prod.yaml`, replace the hardcoded `DomainCertificateArn="arn:aws:acm:..."` parameter override with `DomainCertificateArn=${{ vars.DOMAIN_CERTIFICATE_ARN }}`. Must change `.github/workflows/`. Do not print the ARN in evidence. Document ops residual: set the GitHub Environment variable before the next prod deploy.
+Introduce a KeycloakService helper (e.g. `getTokenClaims()`) that returns `keycloakAuth.tokenParsed` for real sessions. Route `isAuthorized`, `isAdmin`, `getWelcomeMessage`, `getIdpFromToken`, and any other KeycloakService JwtUtil.decodeToken call sites for authz/identity through that helper. Unit tests assert tokenParsed is used and JwtUtil.decodeToken is not invoked on the real-auth path. Must change `src/`.
 
 ## Architecture
 
 ```text
-lza-deploy-admin-prod.yaml
-  SAM Deploy --parameter-overrides
-    DomainCertificateArn=${{ vars.DOMAIN_CERTIFICATE_ARN }}
-GitHub Environment (prod / lza-prod)
-  vars.DOMAIN_CERTIFICATE_ARN  (human-set residual)
+KeycloakService.getTokenClaims()
+  -> keycloakAuth.tokenParsed
+isAuthorized / isAdmin / getWelcomeMessage / getIdpFromToken / …
+  -> getTokenClaims()   // was JwtUtil.decodeToken(getToken())
 ```
 
 ## Key decisions
 
 | Decision | Choice | Rationale |
 | --- | --- | --- |
-| Source | `vars.DOMAIN_CERTIFICATE_ARN` | Matches assessment Expected |
-| Evidence | No ARN reprint | Avoid re-leaking |
-| Ops var | Residual, not blocking code merge | Code fix is complete when workflow references vars |
+| Source of truth | Keycloak `tokenParsed` | Library-verified with session |
+| JwtUtil | Leave utility; stop using on real-auth claim path | Matches assessment intent |
+| Tests | Unit spies | No live IdP |
 
 ## Tasks
 
-1. Replace literal DomainCertificateArn in prod LZA workflow with vars reference
-2. Append evidence (no ARN value)
-3. Checkpoint 3 + merge (must change `.github/workflows/`)
+1. Add getTokenClaims (or equivalent); rewire KeycloakService claim consumers
+2. Unit tests for claim source on real-auth path
+3. Append evidence
+4. Checkpoint 3 + merge (must change `src/`)
 
 ## Approval (checkpoint 2)
 

--- a/spec/tasks.md
+++ b/spec/tasks.md
@@ -1,5 +1,7 @@
-# Tasks — SECRET-001 (active)
+# Tasks — AUTH-002 (active)
 
-- [x] In `.github/workflows/lza-deploy-admin-prod.yaml`, set `DomainCertificateArn=${{ vars.DOMAIN_CERTIFICATE_ARN }}` (remove literal ACM ARN)
-- [x] Append `docs/pr-evidence.md` for SECRET-001 without printing the ARN value; note ops residual to set the GitHub Environment variable
-- [ ] Checkpoint 3 + merge (must change `.github/workflows/`; refuse evidence-only)
+- [ ] Add `getTokenClaims()` (or equivalent) on `KeycloakService` returning `keycloakAuth.tokenParsed` for real sessions
+- [ ] Rewire `isAuthorized`, `isAdmin`, `getWelcomeMessage`, `getIdpFromToken`, and other KeycloakService authz/identity helpers to use it (not `JwtUtil.decodeToken` on the real-auth path)
+- [ ] Add/update unit tests asserting tokenParsed is used and JwtUtil.decodeToken is not used on that path
+- [ ] Append `docs/pr-evidence.md` for AUTH-002 (do not overwrite prior slices)
+- [ ] Checkpoint 3 + merge (must change `src/`; refuse evidence-only)


### PR DESCRIPTION
## Summary

- Plan + tasks for AUTH-002 (#69) in one commit.

## Test plan

- [ ] Checkpoint 2 (Jordan Lee) → merge → ready-for-agent

Made with [Cursor](https://cursor.com)